### PR TITLE
validator_derive: Properly skip foreign attributes.

### DIFF
--- a/validator_derive/src/lib.rs
+++ b/validator_derive/src/lib.rs
@@ -313,12 +313,11 @@ fn find_struct_validation(struct_attrs: &Vec<syn::Attribute>) -> Option<SchemaVa
     };
 
     for attr in struct_attrs {
+        if attr.value.name() != "validate" {
+            continue;
+        }
         match attr.value {
             syn::MetaItem::List(ref ident, ref meta_items) => {
-                if ident != "validate" {
-                    continue;
-                }
-
                 match meta_items[0] {
                     syn::NestedMetaItem::MetaItem(ref item) => match item {
                         &syn::MetaItem::List(ref ident2, ref args) => {

--- a/validator_derive/src/lib.rs
+++ b/validator_derive/src/lib.rs
@@ -317,7 +317,7 @@ fn find_struct_validation(struct_attrs: &Vec<syn::Attribute>) -> Option<SchemaVa
             continue;
         }
         match attr.value {
-            syn::MetaItem::List(ref ident, ref meta_items) => {
+            syn::MetaItem::List(_, ref meta_items) => {
                 match meta_items[0] {
                     syn::NestedMetaItem::MetaItem(ref item) => match item {
                         &syn::MetaItem::List(ref ident2, ref args) => {


### PR DESCRIPTION
The old code only skips attributes if they are MetaItem::List.

This was interfering with other struct level attributes for me.

With a simple change, all attributes are skipped if they are not named "validate".

