### PR TITLE
Implement Error and Display for ValidationErrors

### DIFF
--- a/validator/src/types.rs
+++ b/validator/src/types.rs
@@ -59,3 +59,14 @@ impl ValidationErrors {
         self.0.is_empty()
     }
 }
+
+impl std::error::Error for ValidationErrors {
+    fn description(&self) -> &str { "Validation failed" }
+    fn cause(&self) -> Option<&std::error::Error> { None }
+}
+
+impl fmt::Display for ValidationErrors {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Debug::fmt(self, fmt)
+    }
+}

--- a/validator_derive/tests/complex.rs
+++ b/validator_derive/tests/complex.rs
@@ -9,7 +9,7 @@ extern crate regex;
 extern crate lazy_static;
 
 use regex::Regex;
-use validator::{Validate, ValidationError};
+use validator::{Validate, ValidationError, ValidationErrors};
 
 
 fn validate_unique_username(username: &str) -> Result<(), ValidationError> {
@@ -152,4 +152,21 @@ fn test_can_validate_option_fields_without_lifetime() {
         custom: Some("hey".to_string()),
     };
     assert!(s.validate().is_ok());
+}
+
+#[test]
+fn test_works_with_question_mark_operator() {
+    fn some_fn() -> Result<(), ValidationErrors> {
+        let signup = SignupData {
+            mail: "invalid_email".to_string(),
+            site: "http://hello.com".to_string(),
+            first_name: "Bob".to_string(),
+            age: 18,
+        };
+
+        signup.validate()?;
+        Ok(())
+    }
+
+    assert!(some_fn().is_err());
 }


### PR DESCRIPTION
Fixes #29.

I couldn't come up with a better implementation of `fmt::Display` so it's just `fmt::Debug` for now.