### PR TITLE
Fix path parsing for custom validators

### DIFF
--- a/validator_derive/Cargo.toml
+++ b/validator_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "validator_derive"
-version = "0.6.2"
+version = "0.6.3"
 authors = ["Vincent Prouillet <vincent@wearewizards.io>"]
 license = "MIT"
 description = "Macros 1.1 implementation of #[derive(Validate)]"

--- a/validator_derive/src/quoting.rs
+++ b/validator_derive/src/quoting.rs
@@ -250,7 +250,7 @@ pub fn quote_custom_validation(field_quoter: &FieldQuoter, validation: &FieldVal
     let validator_param = field_quoter.quote_validator_param();
 
     if let Validator::Custom(ref fun) = validation.validator {
-        let fn_ident = syn::Ident::from(fun.clone());
+        let fn_ident: syn::Path = syn::parse_str(fun).unwrap();
         let add_message_quoted = if let Some(ref m) = validation.message {
             quote!(err.message = Some(::std::borrow::Cow::from(#m));)
         } else {

--- a/validator_derive/tests/run-pass/custom.rs
+++ b/validator_derive/tests/run-pass/custom.rs
@@ -10,6 +10,12 @@ struct Test {
     s: String,
 }
 
+#[derive(Validate)]
+struct TestPath {
+    #[validate(custom = "::validate_something")]
+    s: String,
+}
+
 fn validate_something(s: &str) -> Result<(), ValidationError> {
     Ok(())
 }


### PR DESCRIPTION
`::foo::bar` isn't a valid ident in syn 0.12. This lead to some code
failing to compile if it was using paths as custom validators.
This fixes it and adds a test.