### PR TITLE
Added support for validating Cow<'a, str> fields.

### DIFF
--- a/validator/src/traits.rs
+++ b/validator/src/traits.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::collections::HashMap;
 
 use types::ValidationErrors;
@@ -26,6 +27,12 @@ impl<'a> HasLen for &'a String {
 impl<'a> HasLen for &'a str {
     fn length(&self) -> u64 {
         self.chars().count() as u64
+    }
+}
+
+impl<'a> HasLen for Cow<'a, str> {
+    fn length(&self) -> u64 {
+        self.len() as u64
     }
 }
 
@@ -59,6 +66,12 @@ impl<'a> Contains for &'a String {
 }
 
 impl<'a> Contains for &'a str {
+    fn has_element(&self, needle: &str) -> bool {
+        self.contains(needle)
+    }
+}
+
+impl<'a> Contains for Cow<'a, str> {
     fn has_element(&self, needle: &str) -> bool {
         self.contains(needle)
     }

--- a/validator/src/validation/cards.rs
+++ b/validator/src/validation/cards.rs
@@ -1,13 +1,20 @@
+use std::borrow::Cow;
+
 use card_validate::{Validate as CardValidate};
 
 
-pub fn validate_credit_card(card: &str) -> bool {
-    CardValidate::from(card).is_ok()
+pub fn validate_credit_card<'a, T>(card: T) -> bool
+    where T: Into<Cow<'a, str>>
+{
+    CardValidate::from(&card.into()).is_ok()
 }
 
 #[cfg(test)]
 mod tests {
+    use std::borrow::Cow;
+
     use super::validate_credit_card;
+
     #[test]
     fn test_credit_card() {
         let tests = vec![
@@ -20,5 +27,17 @@ mod tests {
         for (input, expected) in tests {
             assert_eq!(validate_credit_card(input), expected);
         }
+    }
+
+    #[test]
+    fn test_credit_card_cow() {
+        let test: Cow<'static, str> = "4539571147647251".into();
+        assert_eq!(validate_credit_card(test), true);
+        let test: Cow<'static, str> = String::from("4539571147647251").into();
+        assert_eq!(validate_credit_card(test), true);
+        let test: Cow<'static, str> = "5236313877109141".into();
+        assert_eq!(validate_credit_card(test), false);
+        let test: Cow<'static, str> = String::from("5236313877109141").into();
+        assert_eq!(validate_credit_card(test), false);
     }
 }

--- a/validator/src/validation/contains.rs
+++ b/validator/src/validation/contains.rs
@@ -9,6 +9,7 @@ pub fn validate_contains<T: Contains>(val: T, needle: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use std::borrow::Cow;
     use std::collections::HashMap;
 
     use super::*;
@@ -35,5 +36,21 @@ mod tests {
         let mut map = HashMap::new();
         map.insert("hey".to_string(), 1);
         assert_eq!(validate_contains(map, "bob"), false);
+    }
+
+    #[test]
+    fn test_validate_contains_cow() {
+        let test: Cow<'static, str> = "hey".into();
+        assert!(validate_contains(test, "e"));
+        let test: Cow<'static, str> = String::from("hey").into();
+        assert!(validate_contains(test, "e"));
+    }
+
+    #[test]
+    fn test_validate_contains_cow_can_fail() {
+        let test: Cow<'static, str> = "hey".into();
+        assert_eq!(validate_contains(test, "o"), false);
+        let test: Cow<'static, str> = String::from("hey").into();
+        assert_eq!(validate_contains(test, "o"), false);
     }
 }

--- a/validator/src/validation/ip.rs
+++ b/validator/src/validation/ip.rs
@@ -1,10 +1,13 @@
-use std::str::FromStr;
+use std::borrow::Cow;
 use std::net::IpAddr;
+use std::str::FromStr;
 
 
 /// Validates whether the given string is an IP V4
-pub fn validate_ip_v4(val: &str) -> bool {
-    match IpAddr::from_str(val) {
+pub fn validate_ip_v4<'a, T>(val: T) -> bool
+    where T: Into<Cow<'a, str>>
+{
+    match IpAddr::from_str(val.into().as_ref()) {
         Ok(i) => match i {
             IpAddr::V4(_) => true,
             IpAddr::V6(_) => false,
@@ -14,8 +17,10 @@ pub fn validate_ip_v4(val: &str) -> bool {
 }
 
 /// Validates whether the given string is an IP V6
-pub fn validate_ip_v6(val: &str) -> bool {
-    match IpAddr::from_str(val) {
+pub fn validate_ip_v6<'a, T>(val: T) -> bool
+    where T: Into<Cow<'a, str>>
+{
+    match IpAddr::from_str(val.into().as_ref()) {
         Ok(i) => match i {
             IpAddr::V4(_) => false,
             IpAddr::V6(_) => true,
@@ -25,8 +30,10 @@ pub fn validate_ip_v6(val: &str) -> bool {
 }
 
 /// Validates whether the given string is an IP
-pub fn validate_ip(val: &str) -> bool {
-    match IpAddr::from_str(val) {
+pub fn validate_ip<'a, T>(val: T) -> bool
+    where T: Into<Cow<'a, str>>
+{
+    match IpAddr::from_str(val.into().as_ref()) {
         Ok(_) => true,
         Err(_) => false,
     }
@@ -35,6 +42,8 @@ pub fn validate_ip(val: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use std::borrow::Cow;
+
     use super::{validate_ip_v4, validate_ip_v6, validate_ip};
 
     #[test]
@@ -57,6 +66,18 @@ mod tests {
     }
 
     #[test]
+    fn test_validate_ip_cow() {
+        let test: Cow<'static, str> = "1.1.1.1".into();
+        assert_eq!(validate_ip(test), true);
+        let test: Cow<'static, str> = String::from("1.1.1.1").into();
+        assert_eq!(validate_ip(test), true);
+        let test: Cow<'static, str> = "2a02::223:6cff :fe8a:2e8a".into();
+        assert_eq!(validate_ip(test), false);
+        let test: Cow<'static, str> = String::from("2a02::223:6cff :fe8a:2e8a").into();
+        assert_eq!(validate_ip(test), false);
+    }
+
+    #[test]
     fn test_validate_ip_v4() {
         let tests = vec![
             ("1.1.1.1", true),
@@ -73,6 +94,18 @@ mod tests {
         for (input, expected) in tests {
             assert_eq!(validate_ip_v4(input), expected);
         }
+    }
+
+    #[test]
+    fn test_validate_ip_v4_cow() {
+        let test: Cow<'static, str> = "1.1.1.1".into();
+        assert_eq!(validate_ip_v4(test), true);
+        let test: Cow<'static, str> = String::from("1.1.1.1").into();
+        assert_eq!(validate_ip_v4(test), true);
+        let test: Cow<'static, str> = "٧.2٥.3٣.243".into();
+        assert_eq!(validate_ip_v4(test), false);
+        let test: Cow<'static, str> = String::from("٧.2٥.3٣.243").into();
+        assert_eq!(validate_ip_v4(test), false);
     }
 
     #[test]
@@ -103,5 +136,17 @@ mod tests {
         for (input, expected) in tests {
             assert_eq!(validate_ip_v6(input), expected);
         }
+    }
+
+    #[test]
+    fn test_validate_ip_v6_cow() {
+        let test: Cow<'static, str> = "fe80::223:6cff:fe8a:2e8a".into();
+        assert_eq!(validate_ip_v6(test), true);
+        let test: Cow<'static, str> = String::from("fe80::223:6cff:fe8a:2e8a").into();
+        assert_eq!(validate_ip_v6(test), true);
+        let test: Cow<'static, str> = "::ffff:zzzz:0a0a".into();
+        assert_eq!(validate_ip_v6(test), false);
+        let test: Cow<'static, str> = String::from("::ffff:zzzz:0a0a").into();
+        assert_eq!(validate_ip_v6(test), false);
     }
 }

--- a/validator/src/validation/length.rs
+++ b/validator/src/validation/length.rs
@@ -32,6 +32,8 @@ pub fn validate_length<T: HasLen>(length: Validator, val: T) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use std::borrow::Cow;
+
     use super::{validate_length, Validator};
 
     #[test]
@@ -56,6 +58,16 @@ mod tests {
     fn test_validate_length_string_max_only() {
         let validator = Validator::Length { min: None, max: Some(1), equal: None };
         assert_eq!(validate_length(validator, "hello"), false);
+    }
+
+    #[test]
+    fn test_validate_length_cow() {
+        let validator = Validator::Length { min: Some(1), max: Some(2), equal: Some(5) };
+        let test: Cow<'static, str> = "hello".into();
+        assert_eq!(validate_length(validator, test), true);
+        let validator = Validator::Length { min: Some(1), max: Some(2), equal: Some(5) };
+        let test: Cow<'static, str> = String::from("hello").into();
+        assert_eq!(validate_length(validator, test), true);
     }
 
     #[test]

--- a/validator/src/validation/must_match.rs
+++ b/validator/src/validation/must_match.rs
@@ -6,11 +6,20 @@ pub fn validate_must_match<T: Eq>(a: T, b: T) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use std::borrow::Cow;
+
     use super::{validate_must_match};
 
     #[test]
     fn test_validate_must_match_strings_valid() {
         assert!(validate_must_match("hey".to_string(), "hey".to_string()))
+    }
+
+    #[test]
+    fn test_validate_must_match_cows_valid() {
+        let left: Cow<'static, str> = "hey".into();
+        let right: Cow<'static, str> = String::from("hey").into();
+        assert!(validate_must_match(left, right))
     }
 
     #[test]
@@ -22,5 +31,4 @@ mod tests {
     fn test_validate_must_match_numbers_false() {
         assert_eq!(false, validate_must_match(2, 3));
     }
-
 }

--- a/validator/src/validation/phone.rs
+++ b/validator/src/validation/phone.rs
@@ -1,8 +1,11 @@
 use phonenumber;
+use std::borrow::Cow;
 
 
-pub fn validate_phone(phone_number: &str) -> bool {
-    if let Ok(parsed) = phonenumber::parse(None, phone_number) {
+pub fn validate_phone<'a, T>(phone_number: T) -> bool
+    where T: Into<Cow<'a, str>>
+{
+    if let Ok(parsed) = phonenumber::parse(None, phone_number.into()) {
         phonenumber::is_valid(&parsed)
     } else {
         false
@@ -11,7 +14,10 @@ pub fn validate_phone(phone_number: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use std::borrow::Cow;
+
     use super::validate_phone;
+
     #[test]
     fn test_phone() {
         let tests = vec![
@@ -29,5 +35,17 @@ mod tests {
             println!("{} - {}", input, expected);
             assert_eq!(validate_phone(input), expected);
         }
+    }
+
+    #[test]
+    fn test_phone_cow() {
+        let test: Cow<'static, str> = "+1 (415) 237-0800".into();
+        assert_eq!(validate_phone(test), true);
+        let test: Cow<'static, str> = String::from("+1 (415) 237-0800").into();
+        assert_eq!(validate_phone(test), true);
+        let test: Cow<'static, str> = "TEXT".into();
+        assert_eq!(validate_phone(test), false);
+        let test: Cow<'static, str> = String::from("TEXT").into();
+        assert_eq!(validate_phone(test), false);
     }
 }

--- a/validator/src/validation/urls.rs
+++ b/validator/src/validation/urls.rs
@@ -1,9 +1,12 @@
+use std::borrow::Cow;
 use url::Url;
 
 
 /// Validates whether the string given is a url
-pub fn validate_url(val: &str) -> bool {
-    match Url::parse(val) {
+pub fn validate_url<'a, T>(val: T) -> bool
+    where T: Into<Cow<'a, str>>
+{
+    match Url::parse(val.into().as_ref()) {
         Ok(_) => true,
         Err(_) => false,
     }
@@ -11,6 +14,8 @@ pub fn validate_url(val: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use std::borrow::Cow;
+
     use super::{validate_url};
 
 
@@ -26,5 +31,17 @@ mod tests {
         for (url, expected) in tests {
             assert_eq!(validate_url(url), expected);
         }
+    }
+
+    #[test]
+    fn test_validate_url_cow() {
+        let test: Cow<'static, str> = "http://localhost:80".into();
+        assert_eq!(validate_url(test), true);
+        let test: Cow<'static, str> = String::from("http://localhost:80").into();
+        assert_eq!(validate_url(test), true);
+        let test: Cow<'static, str> = "http".into();
+        assert_eq!(validate_url(test), false);
+        let test: Cow<'static, str> = String::from("http").into();
+        assert_eq!(validate_url(test), false);
     }
 }

--- a/validator_derive/Cargo.toml
+++ b/validator_derive/Cargo.toml
@@ -21,13 +21,13 @@ quote = "0.6"
 proc-macro2 = "0.4"
 if_chain = "0"
 validator = { version = "0.7", path = "../validator"}
+regex = "1"
+lazy_static = "1"
 
 [dev-dependencies]
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 compiletest_rs = "0.3"
-regex = "1"
-lazy_static = "1"
 
 

--- a/validator_derive/src/asserts.rs
+++ b/validator_derive/src/asserts.rs
@@ -1,3 +1,8 @@
+use regex::Regex;
+
+lazy_static! {
+    pub static ref COW_TYPE: Regex = Regex::new(r"Cow<'[a-z]+,str>").unwrap();
+}
 
 pub static NUMBER_TYPES: [&'static str; 36] = [
     "usize", "u8", "u16", "u32", "u64",
@@ -17,11 +22,12 @@ pub static NUMBER_TYPES: [&'static str; 36] = [
 pub fn assert_string_type(name: &str, field_type: &String) {
     if field_type != "String"
         && field_type != "&str"
+        && !COW_TYPE.is_match(field_type)
         && field_type != "Option<String>"
         && field_type != "Option<Option<String>>"
         && !(field_type.starts_with("Option<") && field_type.ends_with("str>"))
         && !(field_type.starts_with("Option<Option<") && field_type.ends_with("str>>")) {
-        panic!("`{}` validator can only be used on String, &str or an Option of those", name);
+        panic!("`{}` validator can only be used on String, &str, Cow<'_,str> or an Option of those", name);
     }
 }
 
@@ -45,9 +51,10 @@ pub fn assert_has_len(field_name: String, field_type: &String) {
         // a bit ugly
         && !(field_type.starts_with("Option<") && field_type.ends_with("str>"))
         && !(field_type.starts_with("Option<Option<") && field_type.ends_with("str>>"))
+        && !COW_TYPE.is_match(field_type)
         && field_type != "&str" {
             panic!(
-                "Validator `length` can only be used on types `String`, `&str` or `Vec` but found `{}` for field `{}`",
+                "Validator `length` can only be used on types `String`, `&str`, Cow<'_,str> or `Vec` but found `{}` for field `{}`",
                 field_type, field_name
             );
     }

--- a/validator_derive/src/lib.rs
+++ b/validator_derive/src/lib.rs
@@ -1,20 +1,21 @@
 #![recursion_limit = "128"]
 
 #[macro_use]
-extern crate quote;
+extern crate if_chain;
+#[macro_use]
+extern crate lazy_static;
 extern crate proc_macro;
 extern crate proc_macro2;
 #[macro_use]
-extern crate syn;
+extern crate quote;
+extern crate regex;
 #[macro_use]
-extern crate if_chain;
+extern crate syn;
 extern crate validator;
-
-use std::collections::HashMap;
 
 use proc_macro::TokenStream;
 use quote::ToTokens;
-
+use std::collections::HashMap;
 use validator::Validator;
 
 

--- a/validator_derive/src/quoting.rs
+++ b/validator_derive/src/quoting.rs
@@ -4,7 +4,7 @@ use proc_macro2::{self, Span};
 
 use lit::option_u64_to_tokens;
 use validation::{FieldValidation, SchemaValidation};
-use asserts::NUMBER_TYPES;
+use asserts::{COW_TYPE, NUMBER_TYPES};
 
 
 /// Pass around all the information needed for creating a validation
@@ -31,6 +31,8 @@ impl FieldQuoter {
 
         if self._type.starts_with("Option<") {
             quote!(#ident)
+        } else if COW_TYPE.is_match(&self._type.as_ref()) {
+            quote!(self.#ident.as_ref())
         } else if self._type.starts_with("&") || NUMBER_TYPES.contains(&self._type.as_ref()) {
             quote!(self.#ident)
         } else {

--- a/validator_derive/tests/compile-fail/length/wrong_type.rs
+++ b/validator_derive/tests/compile-fail/length/wrong_type.rs
@@ -4,7 +4,7 @@ use validator::Validate;
 
 #[derive(Validate)]
 //~^ ERROR: proc-macro derive panicked
-//~^^ HELP: "Validator `length` can only be used on types `String`, `&str`, Cow<'_,str> or `Vec` but found `{}` for field `{}`"
+//~^^ HELP: Validator `length` can only be used on types `String`, `&str`, Cow<'_,str> or `Vec` but found `usize`
 struct Test {
     #[validate(length())]
     s: usize,

--- a/validator_derive/tests/compile-fail/length/wrong_type.rs
+++ b/validator_derive/tests/compile-fail/length/wrong_type.rs
@@ -4,7 +4,7 @@ use validator::Validate;
 
 #[derive(Validate)]
 //~^ ERROR: proc-macro derive panicked
-//~^^ HELP: Validator `length` can only be used on types `String`, `&str` or `Vec` but found `usize`
+//~^^ HELP: "Validator `length` can only be used on types `String`, `&str`, Cow<'_,str> or `Vec` but found `{}` for field `{}`"
 struct Test {
     #[validate(length())]
     s: usize,


### PR DESCRIPTION
Refactored validate functions to accept parameters that are `Into<Cow<'a, str>>` and added `HasLen` and `Contains` trait implementations for the `Cow<'a, str>` type.
Modified assertion and quoting logic to correctly derive validations for <Cow<'a, str>` fields.
Extended test suite to include examples using this type.

#55