### PR TITLE
Nested Validation

### DIFF
--- a/validator/src/lib.rs
+++ b/validator/src/lib.rs
@@ -29,5 +29,5 @@ pub use validation::cards::validate_credit_card;
 pub use validation::phone::validate_phone;
 pub use validation::Validator;
 
-pub use types::{ValidationError, ValidationErrors, ValidationPath};
+pub use types::{ValidationError, ValidationErrors, ValidationErrorsKind};
 pub use traits::{Validate, HasLen, Contains};

--- a/validator/src/lib.rs
+++ b/validator/src/lib.rs
@@ -29,5 +29,5 @@ pub use validation::cards::validate_credit_card;
 pub use validation::phone::validate_phone;
 pub use validation::Validator;
 
-pub use types::{FieldPath, ValidationError, ValidationErrors};
+pub use types::{ValidationError, ValidationErrors, ValidationPath};
 pub use traits::{Validate, HasLen, Contains};

--- a/validator/src/lib.rs
+++ b/validator/src/lib.rs
@@ -29,5 +29,5 @@ pub use validation::cards::validate_credit_card;
 pub use validation::phone::validate_phone;
 pub use validation::Validator;
 
-pub use types::{ValidationErrors, ValidationError};
+pub use types::{FieldPath, ValidationError, ValidationErrors};
 pub use traits::{Validate, HasLen, Contains};

--- a/validator/src/traits.rs
+++ b/validator/src/traits.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 use std::collections::HashMap;
 
-use types::{FieldPath, ValidationErrors};
+use types::{ValidationErrors, ValidationPath};
 
 
 /// Trait to implement if one wants to make the `length` validator
@@ -91,9 +91,11 @@ impl<'a, S> Contains for &'a HashMap<String, S> {
 
 /// The trait that `validator_derive` implements
 pub trait Validate {
-    fn validate(&self) -> Result<(), ValidationErrors>;
+    fn validate(&self) -> Result<(), ValidationErrors> {
+        self.validate_path(ValidationPath::new())
+    }
 
-    fn nested_validate(&self, _path: FieldPath) -> Result<(), ValidationErrors> {
+    fn validate_path(&self, _path: ValidationPath) -> Result<(), ValidationErrors> {
         Ok(())
     }
 }

--- a/validator/src/traits.rs
+++ b/validator/src/traits.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 use std::collections::HashMap;
 
-use types::ValidationErrors;
+use types::{FieldPath, ValidationErrors};
 
 
 /// Trait to implement if one wants to make the `length` validator
@@ -93,13 +93,7 @@ impl<'a, S> Contains for &'a HashMap<String, S> {
 pub trait Validate {
     fn validate(&self) -> Result<(), ValidationErrors>;
 
-    fn nested_validate(&self, result: Result<(), ValidationErrors>) -> Result<(), ValidationErrors> {
-        match self.validate() {
-            Ok(()) => result,
-            Err(nested_errors) => match result {
-                Ok(()) => Err(nested_errors),
-                Err(errors) => Err(errors.merge(nested_errors))
-            }
-        }
+    fn nested_validate(&self, _path: FieldPath) -> Result<(), ValidationErrors> {
+        Ok(())
     }
 }

--- a/validator/src/traits.rs
+++ b/validator/src/traits.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 use std::collections::HashMap;
 
-use types::{ValidationErrors, ValidationPath};
+use types::ValidationErrors;
 
 
 /// Trait to implement if one wants to make the `length` validator
@@ -91,11 +91,5 @@ impl<'a, S> Contains for &'a HashMap<String, S> {
 
 /// The trait that `validator_derive` implements
 pub trait Validate {
-    fn validate(&self) -> Result<(), ValidationErrors> {
-        self.validate_path(ValidationPath::new())
-    }
-
-    fn validate_path(&self, _path: ValidationPath) -> Result<(), ValidationErrors> {
-        Ok(())
-    }
+    fn validate(&self) -> Result<(), ValidationErrors>;
 }

--- a/validator/src/traits.rs
+++ b/validator/src/traits.rs
@@ -92,4 +92,14 @@ impl<'a, S> Contains for &'a HashMap<String, S> {
 /// The trait that `validator_derive` implements
 pub trait Validate {
     fn validate(&self) -> Result<(), ValidationErrors>;
+
+    fn nested_validate(&self, result: Result<(), ValidationErrors>) -> Result<(), ValidationErrors> {
+        match self.validate() {
+            Ok(()) => result,
+            Err(nested_errors) => match result {
+                Ok(()) => Err(nested_errors),
+                Err(errors) => Err(errors.merge(nested_errors))
+            }
+        }
+    }
 }

--- a/validator/src/types.rs
+++ b/validator/src/types.rs
@@ -55,6 +55,11 @@ impl ValidationErrors {
         self.0.entry(field).or_insert_with(|| vec![]).push(error);
     }
 
+    pub fn merge(mut self, other: ValidationErrors) -> Self {
+        self.0.extend(other.inner());
+        self
+    }
+
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
     }

--- a/validator/src/types.rs
+++ b/validator/src/types.rs
@@ -90,8 +90,22 @@ impl ValidationErrors {
         }
     }
 
-    pub fn inner(self) -> HashMap<&'static str, ValidationErrorsKind> {
+    /// Returns a map of field-level validation errors found for the struct that was validated and
+    /// any of it's nested structs that are tagged for validation.
+    pub fn errors(self) -> HashMap<&'static str, ValidationErrorsKind> {
         self.0
+    }
+
+    /// Returns a map of only field-level validation errors found for the struct that was validated.
+    pub fn field_errors(self) -> HashMap<&'static str, Vec<ValidationError>> {
+        self.0.into_iter()
+            .filter_map(|(k, v)| if let ValidationErrorsKind::Field(errors) = v { Some((k, errors)) } else { None })
+            .collect()
+    }
+
+    #[deprecated(since="0.7.3", note="Use `field_errors` instead, or `errors` to also access any errors from nested structs")]
+    pub fn inner(self) -> HashMap<&'static str, Vec<ValidationError>> {
+        self.field_errors()
     }
 
     pub fn add(&mut self, field: &'static str, error: ValidationError) {

--- a/validator/src/types.rs
+++ b/validator/src/types.rs
@@ -54,6 +54,9 @@ impl ValidationErrors {
         ValidationErrors(HashMap::new())
     }
 
+    /// Returns a boolean indicating whether a validation result includes validation errors for a
+    /// given field. May be used as a condition for performing nested struct validations on a field
+    /// in the absence of field-level validation errors.
     pub fn has_error(result: &Result<(), ValidationErrors>, field: &'static str) -> bool {
         match result {
             Ok(()) => false,
@@ -61,6 +64,8 @@ impl ValidationErrors {
         }
     }
 
+    /// Returns the combined outcome of a struct's validation result along with the nested
+    /// validation result for one of its fields.
     pub fn merge(parent: Result<(), ValidationErrors>, field: &'static str, child: Result<(), ValidationErrors>) -> Result<(), ValidationErrors> {
         match child {
             Ok(()) => parent,
@@ -71,6 +76,8 @@ impl ValidationErrors {
         }
     }
 
+    /// Returns the combined outcome of a struct's validation result along with the nested
+    /// validation result for one of its fields where that field is a vector of validating structs.
     pub fn merge_all(parent: Result<(), ValidationErrors>, field: &'static str, children: Vec<Result<(), ValidationErrors>>) -> Result<(), ValidationErrors> {
         let errors = children.into_iter().enumerate()
             .filter_map(|(i, res)| res.err().map(|mut err| (i, err.remove(field))))

--- a/validator/src/types.rs
+++ b/validator/src/types.rs
@@ -64,7 +64,7 @@ impl ValidationErrors {
         ValidationErrors(HashMap::new(), Vec::new())
     }
 
-    pub fn set_path(mut self, path: &FieldPath) -> Self {
+    pub fn set_path(mut self, path: &ValidationPath) -> Self {
         self.1.extend(path.to_vec());
         self
     }
@@ -74,7 +74,7 @@ impl ValidationErrors {
     }
 
     pub fn add(&mut self, field: &'static str, error: ValidationError) {
-        let path = FieldPath::concat(String::from(field), &self.1, &None);
+        let path = ValidationPath::concat(String::from(field), &self.1, &None);
         self.0.entry(path.join(".")).or_insert_with(|| vec![]).push(error.set_path(path));
     }
 
@@ -99,9 +99,9 @@ impl fmt::Display for ValidationErrors {
     }
 }
 
-pub struct FieldPath(Vec<String>, Option<usize>);
+pub struct ValidationPath(Vec<String>, Option<usize>);
 
-impl FieldPath {
+impl ValidationPath {
     pub fn concat(field: String, path: &Vec<String>, index: &Option<usize>) -> Vec<String> {
         let mut vec = path.to_vec();
         vec.push(field);
@@ -111,16 +111,16 @@ impl FieldPath {
         vec
     }
 
-    pub fn new() -> FieldPath {
-        FieldPath(Vec::new(), None)
+    pub fn new() -> ValidationPath {
+        ValidationPath(Vec::new(), None)
     }
 
-    pub fn child(&self, field: String) -> FieldPath {
-        FieldPath(FieldPath::concat(field, &self.0, &self.1), None)
+    pub fn child(&self, field: String) -> ValidationPath {
+        ValidationPath(ValidationPath::concat(field, &self.0, &self.1), None)
     }
 
-    pub fn index(&self, i: usize) -> FieldPath {
-        FieldPath(self.to_vec(), Some(i))
+    pub fn index(&self, i: usize) -> ValidationPath {
+        ValidationPath(self.to_vec(), Some(i))
     }
 
     pub fn to_vec(&self) -> Vec<String> {

--- a/validator/src/types.rs
+++ b/validator/src/types.rs
@@ -74,7 +74,7 @@ impl ValidationErrors {
     }
 
     pub fn add(&mut self, field: &'static str, error: ValidationError) {
-        let path = FieldPath::concat(Some(String::from(field)), Some(&self.1));
+        let path = FieldPath::concat(String::from(field), &self.1, &None);
         self.0.entry(path.join(".")).or_insert_with(|| vec![]).push(error.set_path(path));
     }
 
@@ -99,19 +99,28 @@ impl fmt::Display for ValidationErrors {
     }
 }
 
-pub struct FieldPath(Vec<String>);
+pub struct FieldPath(Vec<String>, Option<usize>);
 
 impl FieldPath {
-    pub fn concat(field: Option<String>, path: Option<&Vec<String>>) -> Vec<String> {
-        let mut vec = path.map_or(Vec::new(), |p| p.to_vec());
-        if let Some(f) = field {
-            vec.push(f);
+    pub fn concat(field: String, path: &Vec<String>, index: &Option<usize>) -> Vec<String> {
+        let mut vec = path.to_vec();
+        vec.push(field);
+        if let Some(i) = index {
+            vec.push(i.to_string());
         }
         vec
     }
 
-    pub fn new(field: Option<String>, path: Option<&FieldPath>) -> FieldPath {
-        FieldPath(FieldPath::concat(field, path.map(|p| &p.0)))
+    pub fn new() -> FieldPath {
+        FieldPath(Vec::new(), None)
+    }
+
+    pub fn child(&self, field: String) -> FieldPath {
+        FieldPath(FieldPath::concat(field, &self.0, &self.1), None)
+    }
+
+    pub fn index(&self, i: usize) -> FieldPath {
+        FieldPath(self.to_vec(), Some(i))
     }
 
     pub fn to_vec(&self) -> Vec<String> {

--- a/validator/src/types.rs
+++ b/validator/src/types.rs
@@ -1,6 +1,6 @@
 use std::{self, fmt};
 use std::borrow::Cow;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap, hash_map::Entry::Vacant};
 
 use serde_json::{Value, to_value};
 use serde::ser::Serialize;
@@ -8,7 +8,6 @@ use serde::ser::Serialize;
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct ValidationError {
-    pub path: Vec<String>,
     pub code: Cow<'static, str>,
     pub message: Option<Cow<'static, str>>,
     pub params: HashMap<Cow<'static, str>, Value>,
@@ -17,16 +16,10 @@ pub struct ValidationError {
 impl ValidationError {
     pub fn new(code: &'static str) -> ValidationError {
         ValidationError {
-            path: Vec::new(),
             code: Cow::from(code),
             message: None,
             params: HashMap::new(),
         }
-    }
-
-    pub fn set_path(mut self, path: Vec<String>) -> Self {
-        self.path.extend(path.into_iter().clone());
-        self
     }
 
     pub fn add_param<T: Serialize>(&mut self, name: Cow<'static, str>, val: &T) {
@@ -46,45 +39,87 @@ impl std::error::Error for ValidationError {
 }
 
 #[derive(Debug, Serialize, Clone, PartialEq)]
-pub struct ValidationErrors(HashMap<String, Vec<ValidationError>>, Vec<String>);
+#[serde(untagged)]
+pub enum ValidationErrorsKind {
+    Struct(Box<ValidationErrors>),
+    List(BTreeMap<usize, Box<ValidationErrors>>),
+    Field(Vec<ValidationError>),
+}
 
+#[derive(Debug, Serialize, Clone, PartialEq)]
+pub struct ValidationErrors(HashMap<&'static str, ValidationErrorsKind>);
 
 impl ValidationErrors {
-    pub fn merge_results(a: Result<(), ValidationErrors>, b: Result<(), ValidationErrors>) -> Result<(), ValidationErrors> {
-        match a {
-            Ok(()) => b,
-            Err(a_errors) => match b {
-                Ok(()) => Err(a_errors),
-                Err(b_errors) => Err(b_errors.merge(a_errors))
-            }
+    pub fn new() -> ValidationErrors {
+        ValidationErrors(HashMap::new())
+    }
+
+    pub fn has_error(result: &Result<(), ValidationErrors>, field: &'static str) -> bool {
+        match result {
+            Ok(()) => false,
+            Err(ref errs) => errs.contains_key(field),
         }
     }
 
-    pub fn new() -> ValidationErrors {
-        ValidationErrors(HashMap::new(), Vec::new())
+    pub fn merge(parent: Result<(), ValidationErrors>, field: &'static str, child: Result<(), ValidationErrors>) -> Result<(), ValidationErrors> {
+        match child {
+            Ok(()) => parent,
+            Err(errors) => parent.and_then(|_| Err(ValidationErrors::new())).map_err(|mut parent_errors| {
+                parent_errors.add_nested(field, ValidationErrorsKind::Struct(Box::new(errors)));
+                parent_errors
+            })
+        }
     }
 
-    pub fn set_path(mut self, path: &ValidationPath) -> Self {
-        self.1.extend(path.to_vec());
-        self
+    pub fn merge_all(parent: Result<(), ValidationErrors>, field: &'static str, children: Vec<Result<(), ValidationErrors>>) -> Result<(), ValidationErrors> {
+        let errors = children.into_iter().enumerate()
+            .filter_map(|(i, res)| res.err().map(|mut err| (i, err.remove(field))))
+            .filter_map(|(i, entry)| match entry {
+                Some(ValidationErrorsKind::Struct(errors)) => Some((i, errors)),
+                _ => None,
+            })
+            .collect::<BTreeMap<_, _>>();
+
+        if errors.is_empty() {
+            parent
+        } else {
+            parent.and_then(|_| Err(ValidationErrors::new())).map_err(|mut parent_errors| {
+                parent_errors.add_nested(field, ValidationErrorsKind::List(errors));
+                parent_errors
+            })
+        }
     }
 
-    pub fn inner(self) -> HashMap<String, Vec<ValidationError>> {
+    pub fn inner(self) -> HashMap<&'static str, ValidationErrorsKind> {
         self.0
     }
 
     pub fn add(&mut self, field: &'static str, error: ValidationError) {
-        let path = ValidationPath::concat(String::from(field), &self.1, &None);
-        self.0.entry(path.join(".")).or_insert_with(|| vec![]).push(error.set_path(path));
-    }
-
-    pub fn merge(mut self, other: ValidationErrors) -> Self {
-        self.0.extend(other.inner());
-        self
+        if let ValidationErrorsKind::Field(ref mut vec) = self.0.entry(field).or_insert(ValidationErrorsKind::Field(vec![])) {
+            vec.push(error);
+        } else {
+            panic!("Attempt to add field validation to a non-Field ValidationErrorsKind instance");
+        }
     }
 
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
+    }
+
+    fn add_nested(&mut self, field: &'static str, errors: ValidationErrorsKind) {
+        if let Vacant(entry) = self.0.entry(field) {
+            entry.insert(errors);
+        } else {
+            panic!("Attempt to replace non-empty ValidationErrors entry");
+        }
+    }
+
+    fn contains_key(&self, field: &'static str) -> bool {
+        self.0.contains_key(field)
+    }
+
+    fn remove(&mut self, field: &'static str) -> Option<ValidationErrorsKind> {
+        self.0.remove(field)
     }
 }
 
@@ -96,34 +131,5 @@ impl std::error::Error for ValidationErrors {
 impl fmt::Display for ValidationErrors {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt::Debug::fmt(self, fmt)
-    }
-}
-
-pub struct ValidationPath(Vec<String>, Option<usize>);
-
-impl ValidationPath {
-    pub fn concat(field: String, path: &Vec<String>, index: &Option<usize>) -> Vec<String> {
-        let mut vec = path.to_vec();
-        vec.push(field);
-        if let Some(i) = index {
-            vec.push(i.to_string());
-        }
-        vec
-    }
-
-    pub fn new() -> ValidationPath {
-        ValidationPath(Vec::new(), None)
-    }
-
-    pub fn child(&self, field: String) -> ValidationPath {
-        ValidationPath(ValidationPath::concat(field, &self.0, &self.1), None)
-    }
-
-    pub fn index(&self, i: usize) -> ValidationPath {
-        ValidationPath(self.to_vec(), Some(i))
-    }
-
-    pub fn to_vec(&self) -> Vec<String> {
-        self.0.to_vec()
     }
 }

--- a/validator/src/validation/mod.rs
+++ b/validator/src/validation/mod.rs
@@ -40,6 +40,7 @@ pub enum Validator {
     CreditCard,
     #[cfg(feature = "phone")]
     Phone,
+    Nested,
 }
 
 impl Validator {
@@ -57,6 +58,7 @@ impl Validator {
             Validator::CreditCard => "credit_card",
             #[cfg(feature = "phone")]
             Validator::Phone => "phone",
+            Validator::Nested => "nested",
         }
     }
 }

--- a/validator_derive/src/lib.rs
+++ b/validator_derive/src/lib.rs
@@ -72,9 +72,13 @@ fn impl_validate(ast: &syn::DeriveInput) -> proc_macro2::TokenStream {
     let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
     let impl_ast = quote!(
         impl #impl_generics Validate for #ident #ty_generics #where_clause {
-            #[allow(unused_mut)]
             fn validate(&self) -> ::std::result::Result<(), ::validator::ValidationErrors> {
-                let mut errors = ::validator::ValidationErrors::new();
+                self.nested_validate(::validator::FieldPath::new(None, None))
+            }
+
+            #[allow(unused_mut)]
+            fn nested_validate(&self, path: ::validator::FieldPath) -> ::std::result::Result<(), ::validator::ValidationErrors> {
+                let mut errors = ::validator::ValidationErrors::new().set_path(&path);
 
                 #(#validations)*
 

--- a/validator_derive/src/lib.rs
+++ b/validator_derive/src/lib.rs
@@ -73,7 +73,7 @@ fn impl_validate(ast: &syn::DeriveInput) -> proc_macro2::TokenStream {
     let impl_ast = quote!(
         impl #impl_generics Validate for #ident #ty_generics #where_clause {
             fn validate(&self) -> ::std::result::Result<(), ::validator::ValidationErrors> {
-                self.nested_validate(::validator::FieldPath::new(None, None))
+                self.nested_validate(::validator::FieldPath::new())
             }
 
             #[allow(unused_mut)]

--- a/validator_derive/src/lib.rs
+++ b/validator_derive/src/lib.rs
@@ -29,6 +29,7 @@ use validation::*;
 use asserts::{assert_string_type, assert_type_matches, assert_has_len, assert_has_range};
 use quoting::{FieldQuoter, quote_field_validation, quote_schema_validation};
 
+
 #[proc_macro_derive(Validate, attributes(validate))]
 pub fn derive_validation(input: TokenStream) -> TokenStream {
     let ast = syn::parse(input).unwrap();
@@ -73,8 +74,8 @@ fn impl_validate(ast: &syn::DeriveInput) -> proc_macro2::TokenStream {
     let impl_ast = quote!(
         impl #impl_generics Validate for #ident #ty_generics #where_clause {
             #[allow(unused_mut)]
-            fn validate_path(&self, path: ::validator::ValidationPath) -> ::std::result::Result<(), ::validator::ValidationErrors> {
-                let mut errors = ::validator::ValidationErrors::new().set_path(&path);
+            fn validate(&self) -> ::std::result::Result<(), ::validator::ValidationErrors> {
+                let mut errors = ::validator::ValidationErrors::new();
 
                 #(#validations)*
 

--- a/validator_derive/src/lib.rs
+++ b/validator_derive/src/lib.rs
@@ -72,12 +72,8 @@ fn impl_validate(ast: &syn::DeriveInput) -> proc_macro2::TokenStream {
     let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
     let impl_ast = quote!(
         impl #impl_generics Validate for #ident #ty_generics #where_clause {
-            fn validate(&self) -> ::std::result::Result<(), ::validator::ValidationErrors> {
-                self.nested_validate(::validator::FieldPath::new())
-            }
-
             #[allow(unused_mut)]
-            fn nested_validate(&self, path: ::validator::FieldPath) -> ::std::result::Result<(), ::validator::ValidationErrors> {
+            fn validate_path(&self, path: ::validator::ValidationPath) -> ::std::result::Result<(), ::validator::ValidationErrors> {
                 let mut errors = ::validator::ValidationErrors::new().set_path(&path);
 
                 #(#validations)*

--- a/validator_derive/src/lib.rs
+++ b/validator_derive/src/lib.rs
@@ -29,13 +29,10 @@ use validation::*;
 use asserts::{assert_string_type, assert_type_matches, assert_has_len, assert_has_range};
 use quoting::{FieldQuoter, quote_field_validation, quote_schema_validation};
 
-
 #[proc_macro_derive(Validate, attributes(validate))]
 pub fn derive_validation(input: TokenStream) -> TokenStream {
     let ast = syn::parse(input).unwrap();
-
-    let expanded = impl_validate(&ast);
-    expanded.into()
+    impl_validate(&ast).into()
 }
 
 
@@ -52,6 +49,7 @@ fn impl_validate(ast: &syn::DeriveInput) -> proc_macro2::TokenStream {
     };
 
     let mut validations = vec![];
+    let mut nested_validations = vec![];
 
     let field_types = find_fields_type(&fields);
 
@@ -62,7 +60,7 @@ fn impl_validate(ast: &syn::DeriveInput) -> proc_macro2::TokenStream {
         let field_quoter = FieldQuoter::new(field_ident, name, field_type);
 
         for validation in &field_validations {
-            validations.push(quote_field_validation(&field_quoter, validation));
+            quote_field_validation(&field_quoter, validation, &mut validations, &mut nested_validations);
         }
     }
 
@@ -82,11 +80,14 @@ fn impl_validate(ast: &syn::DeriveInput) -> proc_macro2::TokenStream {
 
                 #schema_validation
 
-                if errors.is_empty() {
+                let mut result = if errors.is_empty() {
                     ::std::result::Result::Ok(())
                 } else {
                     ::std::result::Result::Err(errors)
-                }
+                };
+
+                #(#nested_validations)*
+                result
             }
         }
     );
@@ -351,6 +352,9 @@ fn find_validators_for_field(field: &syn::Field, field_types: &HashMap<String, S
                         _ => unreachable!("Found a non Meta while looking for validators")
                     };
                 }
+            },
+            Some(syn::Meta::Word(_)) => {
+                validators.push(FieldValidation::new(Validator::Nested))
             },
             _ => unreachable!("Got something other than a list of attributes while checking field `{}`", field_ident),
         }

--- a/validator_derive/src/quoting.rs
+++ b/validator_derive/src/quoting.rs
@@ -358,7 +358,7 @@ pub fn quote_regex_validation(field_quoter: &FieldQuoter, validation: &FieldVali
 pub fn quote_nested_validation(field_quoter: &FieldQuoter)  -> proc_macro2::TokenStream {
     let field_name = &field_quoter.name;
     let validator_field = field_quoter.quote_validator_field();
-    let quoted = quote!(result = ::validator::ValidationErrors::merge_results(result, #validator_field.nested_validate(path.child(#field_name.to_string()))););
+    let quoted = quote!(result = ::validator::ValidationErrors::merge_results(result, #validator_field.validate_path(path.child(#field_name.to_string()))););
     field_quoter.wrap_if_option(field_quoter.wrap_if_vector(quoted))
 }
 

--- a/validator_derive/src/quoting.rs
+++ b/validator_derive/src/quoting.rs
@@ -328,7 +328,8 @@ pub fn quote_regex_validation(field_quoter: &FieldQuoter, validation: &FieldVali
 
 pub fn quote_nested_validation(field_quoter: &FieldQuoter)  -> proc_macro2::TokenStream {
     let ident = &field_quoter.ident;
-    quote!(result = self.#ident.nested_validate(result);)
+    let name = &field_quoter.name;
+    quote!(result = ::validator::ValidationErrors::merge_results(result, self.#ident.nested_validate(::validator::FieldPath::new(Some(#name), Some(&path))));)
 }
 
 pub fn quote_field_validation(field_quoter: &FieldQuoter, validation: &FieldValidation,

--- a/validator_derive/tests/compile-fail/no_nested_validations.rs
+++ b/validator_derive/tests/compile-fail/no_nested_validations.rs
@@ -3,7 +3,7 @@ extern crate validator;
 use validator::Validate;
 
 #[derive(Validate)]
-//~^ ERROR: no method named `nested_validate` found for type `Nested` in the current scope [E0599]
+//~^ ERROR: no method named `validate_path` found for type `Nested` in the current scope [E0599]
 //~^^ HELP: items from traits can only be used if the trait is implemented and in scope
 struct Test {
     #[validate]

--- a/validator_derive/tests/compile-fail/no_nested_validations.rs
+++ b/validator_derive/tests/compile-fail/no_nested_validations.rs
@@ -3,7 +3,7 @@ extern crate validator;
 use validator::Validate;
 
 #[derive(Validate)]
-//~^ ERROR: no method named `validate_path` found for type `Nested` in the current scope [E0599]
+//~^ ERROR: no method named `validate` found for type `Nested` in the current scope [E0599]
 //~^^ HELP: items from traits can only be used if the trait is implemented and in scope
 struct Test {
     #[validate]

--- a/validator_derive/tests/compile-fail/no_nested_validations.rs
+++ b/validator_derive/tests/compile-fail/no_nested_validations.rs
@@ -1,0 +1,17 @@
+#[macro_use] extern crate validator_derive;
+extern crate validator;
+use validator::Validate;
+
+#[derive(Validate)]
+//~^ ERROR: no method named `nested_validate` found for type `Nested` in the current scope [E0599]
+//~^^ HELP: items from traits can only be used if the trait is implemented and in scope
+struct Test {
+    #[validate]
+    nested: Nested,
+}
+
+struct Nested {
+    value: String
+}
+
+fn main() {}

--- a/validator_derive/tests/complex.rs
+++ b/validator_derive/tests/complex.rs
@@ -1,5 +1,3 @@
-#![feature(box_patterns)]
-
 #[macro_use]
 extern crate validator_derive;
 extern crate validator;

--- a/validator_derive/tests/complex.rs
+++ b/validator_derive/tests/complex.rs
@@ -134,10 +134,10 @@ fn failed_validation_points_to_original_field_name() {
     assert_eq!(errs["card.cvv"].len(), 1);
     assert_eq!(errs["card.cvv"][0].code, "range");
     assert_eq!(errs["card.cvv"][0].path, vec!["card", "cvv"]);
-    assert!(errs.contains_key("preferences[0].name"));
-    assert_eq!(errs["preferences[0].name"].len(), 1);
-    assert_eq!(errs["preferences[0].name"][0].code, "length");
-    assert_eq!(errs["preferences[0].name"][0].path, vec!["preferences[0]", "name"]);
+    assert!(errs.contains_key("preferences.0.name"));
+    assert_eq!(errs["preferences.0.name"].len(), 1);
+    assert_eq!(errs["preferences.0.name"][0].code, "length");
+    assert_eq!(errs["preferences.0.name"][0].path, vec!["preferences", "0", "name"]);
 }
 
 #[test]

--- a/validator_derive/tests/complex.rs
+++ b/validator_derive/tests/complex.rs
@@ -121,7 +121,7 @@ fn failed_validation_points_to_original_field_name() {
     let res = signup.validate();
     // println!("{}", serde_json::to_string(&res).unwrap());
     assert!(res.is_err());
-    let errs = res.unwrap_err().inner();
+    let errs = res.unwrap_err().errors();
     assert!(errs.contains_key("firstName"));
     if let ValidationErrorsKind::Field(ref err) = errs["firstName"] {
         assert_eq!(err.len(), 1);
@@ -338,5 +338,5 @@ fn unwrap_map<F>(errors: &Box<ValidationErrors>, f: F)
     where F: FnOnce(HashMap<&'static str, ValidationErrorsKind>)
 {
     let errors = *errors.clone();
-    f(errors.inner());
+    f(errors.errors());
 }

--- a/validator_derive/tests/contains.rs
+++ b/validator_derive/tests/contains.rs
@@ -2,7 +2,7 @@
 extern crate validator_derive;
 extern crate validator;
 
-use validator::Validate;
+use validator::{Validate, ValidationErrorsKind};
 
 #[test]
 fn can_validate_contains_ok() {
@@ -34,10 +34,14 @@ fn value_not_containing_needle_fails_validation() {
     assert!(res.is_err());
     let errs = res.unwrap_err().inner();
     assert!(errs.contains_key("val"));
-    assert_eq!(errs["val"].len(), 1);
-    assert_eq!(errs["val"][0].code, "contains");
-    assert_eq!(errs["val"][0].params["value"], "");
-    assert_eq!(errs["val"][0].params["needle"], "he");
+    if let ValidationErrorsKind::Field(ref err) = errs["val"] {
+        assert_eq!(err.len(), 1);
+        assert_eq!(err[0].code, "contains");
+        assert_eq!(err[0].params["value"], "");
+        assert_eq!(err[0].params["needle"], "he");
+    } else {
+        panic!("Expected field validation errors");
+    }
 }
 
 #[test]
@@ -54,8 +58,12 @@ fn can_specify_code_for_contains() {
     assert!(res.is_err());
     let errs = res.unwrap_err().inner();
     assert!(errs.contains_key("val"));
-    assert_eq!(errs["val"].len(), 1);
-    assert_eq!(errs["val"][0].code, "oops");
+    if let ValidationErrorsKind::Field(ref err) = errs["val"] {
+        assert_eq!(err.len(), 1);
+        assert_eq!(err[0].code, "oops");
+    } else {
+        panic!("Expected field validation errors");
+    }
 }
 
 #[test]
@@ -72,6 +80,10 @@ fn can_specify_message_for_contains() {
     assert!(res.is_err());
     let errs = res.unwrap_err().inner();
     assert!(errs.contains_key("val"));
-    assert_eq!(errs["val"].len(), 1);
-    assert_eq!(errs["val"][0].clone().message.unwrap(), "oops");
+    if let ValidationErrorsKind::Field(ref err) = errs["val"] {
+        assert_eq!(err.len(), 1);
+        assert_eq!(err[0].clone().message.unwrap(), "oops");
+    } else {
+        panic!("Expected field validation errors");
+    }
 }

--- a/validator_derive/tests/contains.rs
+++ b/validator_derive/tests/contains.rs
@@ -1,8 +1,10 @@
+#![allow(deprecated)]
+
 #[macro_use]
 extern crate validator_derive;
 extern crate validator;
 
-use validator::{Validate, ValidationErrorsKind};
+use validator::Validate;
 
 #[test]
 fn can_validate_contains_ok() {
@@ -34,14 +36,10 @@ fn value_not_containing_needle_fails_validation() {
     assert!(res.is_err());
     let errs = res.unwrap_err().inner();
     assert!(errs.contains_key("val"));
-    if let ValidationErrorsKind::Field(ref err) = errs["val"] {
-        assert_eq!(err.len(), 1);
-        assert_eq!(err[0].code, "contains");
-        assert_eq!(err[0].params["value"], "");
-        assert_eq!(err[0].params["needle"], "he");
-    } else {
-        panic!("Expected field validation errors");
-    }
+    assert_eq!(errs["val"].len(), 1);
+    assert_eq!(errs["val"][0].code, "contains");
+    assert_eq!(errs["val"][0].params["value"], "");
+    assert_eq!(errs["val"][0].params["needle"], "he");
 }
 
 #[test]
@@ -58,12 +56,8 @@ fn can_specify_code_for_contains() {
     assert!(res.is_err());
     let errs = res.unwrap_err().inner();
     assert!(errs.contains_key("val"));
-    if let ValidationErrorsKind::Field(ref err) = errs["val"] {
-        assert_eq!(err.len(), 1);
-        assert_eq!(err[0].code, "oops");
-    } else {
-        panic!("Expected field validation errors");
-    }
+    assert_eq!(errs["val"].len(), 1);
+    assert_eq!(errs["val"][0].code, "oops");
 }
 
 #[test]
@@ -80,10 +74,6 @@ fn can_specify_message_for_contains() {
     assert!(res.is_err());
     let errs = res.unwrap_err().inner();
     assert!(errs.contains_key("val"));
-    if let ValidationErrorsKind::Field(ref err) = errs["val"] {
-        assert_eq!(err.len(), 1);
-        assert_eq!(err[0].clone().message.unwrap(), "oops");
-    } else {
-        panic!("Expected field validation errors");
-    }
+    assert_eq!(errs["val"].len(), 1);
+    assert_eq!(errs["val"][0].clone().message.unwrap(), "oops");
 }

--- a/validator_derive/tests/contains.rs
+++ b/validator_derive/tests/contains.rs
@@ -1,5 +1,3 @@
-#![allow(deprecated)]
-
 #[macro_use]
 extern crate validator_derive;
 extern crate validator;
@@ -34,7 +32,7 @@ fn value_not_containing_needle_fails_validation() {
     };
     let res = s.validate();
     assert!(res.is_err());
-    let errs = res.unwrap_err().inner();
+    let errs = res.unwrap_err().field_errors();
     assert!(errs.contains_key("val"));
     assert_eq!(errs["val"].len(), 1);
     assert_eq!(errs["val"][0].code, "contains");
@@ -54,7 +52,7 @@ fn can_specify_code_for_contains() {
     };
     let res = s.validate();
     assert!(res.is_err());
-    let errs = res.unwrap_err().inner();
+    let errs = res.unwrap_err().field_errors();
     assert!(errs.contains_key("val"));
     assert_eq!(errs["val"].len(), 1);
     assert_eq!(errs["val"][0].code, "oops");
@@ -72,7 +70,7 @@ fn can_specify_message_for_contains() {
     };
     let res = s.validate();
     assert!(res.is_err());
-    let errs = res.unwrap_err().inner();
+    let errs = res.unwrap_err().field_errors();
     assert!(errs.contains_key("val"));
     assert_eq!(errs["val"].len(), 1);
     assert_eq!(errs["val"][0].clone().message.unwrap(), "oops");

--- a/validator_derive/tests/credit_card.rs
+++ b/validator_derive/tests/credit_card.rs
@@ -2,7 +2,7 @@
 extern crate validator_derive;
 extern crate validator;
 
-use validator::Validate;
+use validator::{Validate, ValidationErrorsKind};
 
 #[cfg(feature = "card")]
 #[test]
@@ -36,9 +36,13 @@ fn bad_credit_card_fails_validation() {
     assert!(res.is_err());
     let errs = res.unwrap_err().inner();
     assert!(errs.contains_key("val"));
-    assert_eq!(errs["val"].len(), 1);
-    assert_eq!(errs["val"][0].code, "credit_card");
-    assert_eq!(errs["val"][0].params["value"], "bob");
+    if let ValidationErrorsKind::Field(ref err) = errs["val"] {
+        assert_eq!(err.len(), 1);
+        assert_eq!(err[0].code, "credit_card");
+        assert_eq!(err[0].params["value"], "bob");
+    } else {
+        panic!("Expected field validation errors");
+    }
 }
 
 #[cfg(feature = "card")]
@@ -56,8 +60,12 @@ fn can_specify_code_for_credit_card() {
     assert!(res.is_err());
     let errs = res.unwrap_err().inner();
     assert!(errs.contains_key("val"));
-    assert_eq!(errs["val"].len(), 1);
-    assert_eq!(errs["val"][0].code, "oops");
+    if let ValidationErrorsKind::Field(ref err) = errs["val"] {
+        assert_eq!(err.len(), 1);
+        assert_eq!(err[0].code, "oops");
+    } else {
+        panic!("Expected field validation errors");
+    }
 }
 
 #[cfg(feature = "card")]
@@ -75,6 +83,10 @@ fn can_specify_message_for_credit_card() {
     assert!(res.is_err());
     let errs = res.unwrap_err().inner();
     assert!(errs.contains_key("val"));
-    assert_eq!(errs["val"].len(), 1);
-    assert_eq!(errs["val"][0].clone().message.unwrap(), "oops");
+    if let ValidationErrorsKind::Field(ref err) = errs["val"] {
+        assert_eq!(err.len(), 1);
+        assert_eq!(err[0].clone().message.unwrap(), "oops");
+    } else {
+        panic!("Expected field validation errors");
+    }
 }

--- a/validator_derive/tests/credit_card.rs
+++ b/validator_derive/tests/credit_card.rs
@@ -1,5 +1,3 @@
-#![allow(deprecated)]
-
 #[macro_use]
 extern crate validator_derive;
 extern crate validator;
@@ -36,7 +34,7 @@ fn bad_credit_card_fails_validation() {
     };
     let res = s.validate();
     assert!(res.is_err());
-    let errs = res.unwrap_err().inner();
+    let errs = res.unwrap_err().field_errors();
     assert!(errs.contains_key("val"));
     assert_eq!(errs["val"].len(), 1);
     assert_eq!(errs["val"][0].code, "credit_card");
@@ -56,7 +54,7 @@ fn can_specify_code_for_credit_card() {
     };
     let res = s.validate();
     assert!(res.is_err());
-    let errs = res.unwrap_err().inner();
+    let errs = res.unwrap_err().field_errors();
     assert!(errs.contains_key("val"));
     assert_eq!(errs["val"].len(), 1);
     assert_eq!(errs["val"][0].code, "oops");
@@ -75,7 +73,7 @@ fn can_specify_message_for_credit_card() {
     };
     let res = s.validate();
     assert!(res.is_err());
-    let errs = res.unwrap_err().inner();
+    let errs = res.unwrap_err().field_errors();
     assert!(errs.contains_key("val"));
     assert_eq!(errs["val"].len(), 1);
     assert_eq!(errs["val"][0].clone().message.unwrap(), "oops");

--- a/validator_derive/tests/credit_card.rs
+++ b/validator_derive/tests/credit_card.rs
@@ -1,8 +1,10 @@
+#![allow(deprecated)]
+
 #[macro_use]
 extern crate validator_derive;
 extern crate validator;
 
-use validator::{Validate, ValidationErrorsKind};
+use validator::Validate;
 
 #[cfg(feature = "card")]
 #[test]
@@ -36,13 +38,9 @@ fn bad_credit_card_fails_validation() {
     assert!(res.is_err());
     let errs = res.unwrap_err().inner();
     assert!(errs.contains_key("val"));
-    if let ValidationErrorsKind::Field(ref err) = errs["val"] {
-        assert_eq!(err.len(), 1);
-        assert_eq!(err[0].code, "credit_card");
-        assert_eq!(err[0].params["value"], "bob");
-    } else {
-        panic!("Expected field validation errors");
-    }
+    assert_eq!(errs["val"].len(), 1);
+    assert_eq!(errs["val"][0].code, "credit_card");
+    assert_eq!(errs["val"][0].params["value"], "bob");
 }
 
 #[cfg(feature = "card")]
@@ -60,12 +58,8 @@ fn can_specify_code_for_credit_card() {
     assert!(res.is_err());
     let errs = res.unwrap_err().inner();
     assert!(errs.contains_key("val"));
-    if let ValidationErrorsKind::Field(ref err) = errs["val"] {
-        assert_eq!(err.len(), 1);
-        assert_eq!(err[0].code, "oops");
-    } else {
-        panic!("Expected field validation errors");
-    }
+    assert_eq!(errs["val"].len(), 1);
+    assert_eq!(errs["val"][0].code, "oops");
 }
 
 #[cfg(feature = "card")]
@@ -83,10 +77,6 @@ fn can_specify_message_for_credit_card() {
     assert!(res.is_err());
     let errs = res.unwrap_err().inner();
     assert!(errs.contains_key("val"));
-    if let ValidationErrorsKind::Field(ref err) = errs["val"] {
-        assert_eq!(err.len(), 1);
-        assert_eq!(err[0].clone().message.unwrap(), "oops");
-    } else {
-        panic!("Expected field validation errors");
-    }
+    assert_eq!(errs["val"].len(), 1);
+    assert_eq!(errs["val"][0].clone().message.unwrap(), "oops");
 }

--- a/validator_derive/tests/custom.rs
+++ b/validator_derive/tests/custom.rs
@@ -1,8 +1,10 @@
+#![allow(deprecated)]
+
 #[macro_use]
 extern crate validator_derive;
 extern crate validator;
 
-use validator::{Validate, ValidationError, ValidationErrorsKind};
+use validator::{Validate, ValidationError};
 
 fn valid_custom_fn(_: &str) -> Result<(), ValidationError> {
     Ok(())
@@ -42,13 +44,9 @@ fn can_fail_custom_fn_validation() {
     assert!(res.is_err());
     let errs = res.unwrap_err().inner();
     assert!(errs.contains_key("val"));
-    if let ValidationErrorsKind::Field(ref err) = errs["val"] {
-        assert_eq!(err.len(), 1);
-        assert_eq!(err[0].code, "meh");
-        assert_eq!(err[0].params["value"], "");
-    } else {
-        panic!("Expected field validation errors");
-    }
+    assert_eq!(errs["val"].len(), 1);
+    assert_eq!(errs["val"][0].code, "meh");
+    assert_eq!(errs["val"][0].params["value"], "");
 }
 
 #[test]
@@ -65,10 +63,6 @@ fn can_specify_message_for_custom_fn() {
     assert!(res.is_err());
     let errs = res.unwrap_err().inner();
     assert!(errs.contains_key("val"));
-    if let ValidationErrorsKind::Field(ref err) = errs["val"] {
-        assert_eq!(err.len(), 1);
-        assert_eq!(err[0].clone().message.unwrap(), "oops");
-    } else {
-        panic!("Expected field validation errors");
-    }
+    assert_eq!(errs["val"].len(), 1);
+    assert_eq!(errs["val"][0].clone().message.unwrap(), "oops");
 }

--- a/validator_derive/tests/custom.rs
+++ b/validator_derive/tests/custom.rs
@@ -2,7 +2,7 @@
 extern crate validator_derive;
 extern crate validator;
 
-use validator::{Validate, ValidationError};
+use validator::{Validate, ValidationError, ValidationErrorsKind};
 
 fn valid_custom_fn(_: &str) -> Result<(), ValidationError> {
     Ok(())
@@ -42,9 +42,13 @@ fn can_fail_custom_fn_validation() {
     assert!(res.is_err());
     let errs = res.unwrap_err().inner();
     assert!(errs.contains_key("val"));
-    assert_eq!(errs["val"].len(), 1);
-    assert_eq!(errs["val"][0].code, "meh");
-    assert_eq!(errs["val"][0].params["value"], "");
+    if let ValidationErrorsKind::Field(ref err) = errs["val"] {
+        assert_eq!(err.len(), 1);
+        assert_eq!(err[0].code, "meh");
+        assert_eq!(err[0].params["value"], "");
+    } else {
+        panic!("Expected field validation errors");
+    }
 }
 
 #[test]
@@ -61,6 +65,10 @@ fn can_specify_message_for_custom_fn() {
     assert!(res.is_err());
     let errs = res.unwrap_err().inner();
     assert!(errs.contains_key("val"));
-    assert_eq!(errs["val"].len(), 1);
-    assert_eq!(errs["val"][0].clone().message.unwrap(), "oops");
+    if let ValidationErrorsKind::Field(ref err) = errs["val"] {
+        assert_eq!(err.len(), 1);
+        assert_eq!(err[0].clone().message.unwrap(), "oops");
+    } else {
+        panic!("Expected field validation errors");
+    }
 }

--- a/validator_derive/tests/custom.rs
+++ b/validator_derive/tests/custom.rs
@@ -1,5 +1,3 @@
-#![allow(deprecated)]
-
 #[macro_use]
 extern crate validator_derive;
 extern crate validator;
@@ -42,7 +40,7 @@ fn can_fail_custom_fn_validation() {
     };
     let res = s.validate();
     assert!(res.is_err());
-    let errs = res.unwrap_err().inner();
+    let errs = res.unwrap_err().field_errors();
     assert!(errs.contains_key("val"));
     assert_eq!(errs["val"].len(), 1);
     assert_eq!(errs["val"][0].code, "meh");
@@ -61,7 +59,7 @@ fn can_specify_message_for_custom_fn() {
     };
     let res = s.validate();
     assert!(res.is_err());
-    let errs = res.unwrap_err().inner();
+    let errs = res.unwrap_err().field_errors();
     assert!(errs.contains_key("val"));
     assert_eq!(errs["val"].len(), 1);
     assert_eq!(errs["val"][0].clone().message.unwrap(), "oops");

--- a/validator_derive/tests/email.rs
+++ b/validator_derive/tests/email.rs
@@ -1,5 +1,3 @@
-#![allow(deprecated)]
-
 #[macro_use]
 extern crate validator_derive;
 extern crate validator;
@@ -35,7 +33,7 @@ fn bad_email_fails_validation() {
     };
     let res = s.validate();
     assert!(res.is_err());
-    let errs = res.unwrap_err().inner();
+    let errs = res.unwrap_err().field_errors();
     assert!(errs.contains_key("val"));
     assert_eq!(errs["val"].len(), 1);
     assert_eq!(errs["val"][0].code, "email");
@@ -54,7 +52,7 @@ fn can_specify_code_for_email() {
     };
     let res = s.validate();
     assert!(res.is_err());
-    let errs = res.unwrap_err().inner();
+    let errs = res.unwrap_err().field_errors();
     assert!(errs.contains_key("val"));
     assert_eq!(errs["val"].len(), 1);
     assert_eq!(errs["val"][0].code, "oops");
@@ -72,7 +70,7 @@ fn can_specify_message_for_email() {
     };
     let res = s.validate();
     assert!(res.is_err());
-    let errs = res.unwrap_err().inner();
+    let errs = res.unwrap_err().field_errors();
     assert!(errs.contains_key("val"));
     assert_eq!(errs["val"].len(), 1);
     assert_eq!(errs["val"][0].clone().message.unwrap(), "oops");

--- a/validator_derive/tests/email.rs
+++ b/validator_derive/tests/email.rs
@@ -2,7 +2,7 @@
 extern crate validator_derive;
 extern crate validator;
 
-use validator::Validate;
+use validator::{Validate, ValidationErrorsKind};
 
 
 #[test]
@@ -35,9 +35,13 @@ fn bad_email_fails_validation() {
     assert!(res.is_err());
     let errs = res.unwrap_err().inner();
     assert!(errs.contains_key("val"));
-    assert_eq!(errs["val"].len(), 1);
-    assert_eq!(errs["val"][0].code, "email");
-    assert_eq!(errs["val"][0].params["value"], "bob");
+    if let ValidationErrorsKind::Field(ref err) = errs["val"] {
+        assert_eq!(err.len(), 1);
+        assert_eq!(err[0].code, "email");
+        assert_eq!(err[0].params["value"], "bob");
+    } else {
+        panic!("Expected field validation errors");
+    }
 }
 
 #[test]
@@ -54,8 +58,12 @@ fn can_specify_code_for_email() {
     assert!(res.is_err());
     let errs = res.unwrap_err().inner();
     assert!(errs.contains_key("val"));
-    assert_eq!(errs["val"].len(), 1);
-    assert_eq!(errs["val"][0].code, "oops");
+    if let ValidationErrorsKind::Field(ref err) = errs["val"] {
+        assert_eq!(err.len(), 1);
+        assert_eq!(err[0].code, "oops");
+    } else {
+        panic!("Expected field validation errors");
+    }
 }
 
 #[test]
@@ -72,6 +80,10 @@ fn can_specify_message_for_email() {
     assert!(res.is_err());
     let errs = res.unwrap_err().inner();
     assert!(errs.contains_key("val"));
-    assert_eq!(errs["val"].len(), 1);
-    assert_eq!(errs["val"][0].clone().message.unwrap(), "oops");
+    if let ValidationErrorsKind::Field(ref err) = errs["val"] {
+        assert_eq!(err.len(), 1);
+        assert_eq!(err[0].clone().message.unwrap(), "oops");
+    } else {
+        panic!("Expected field validation errors");
+    }
 }

--- a/validator_derive/tests/email.rs
+++ b/validator_derive/tests/email.rs
@@ -1,8 +1,10 @@
+#![allow(deprecated)]
+
 #[macro_use]
 extern crate validator_derive;
 extern crate validator;
 
-use validator::{Validate, ValidationErrorsKind};
+use validator::Validate;
 
 
 #[test]
@@ -35,13 +37,9 @@ fn bad_email_fails_validation() {
     assert!(res.is_err());
     let errs = res.unwrap_err().inner();
     assert!(errs.contains_key("val"));
-    if let ValidationErrorsKind::Field(ref err) = errs["val"] {
-        assert_eq!(err.len(), 1);
-        assert_eq!(err[0].code, "email");
-        assert_eq!(err[0].params["value"], "bob");
-    } else {
-        panic!("Expected field validation errors");
-    }
+    assert_eq!(errs["val"].len(), 1);
+    assert_eq!(errs["val"][0].code, "email");
+    assert_eq!(errs["val"][0].params["value"], "bob");
 }
 
 #[test]
@@ -58,12 +56,8 @@ fn can_specify_code_for_email() {
     assert!(res.is_err());
     let errs = res.unwrap_err().inner();
     assert!(errs.contains_key("val"));
-    if let ValidationErrorsKind::Field(ref err) = errs["val"] {
-        assert_eq!(err.len(), 1);
-        assert_eq!(err[0].code, "oops");
-    } else {
-        panic!("Expected field validation errors");
-    }
+    assert_eq!(errs["val"].len(), 1);
+    assert_eq!(errs["val"][0].code, "oops");
 }
 
 #[test]
@@ -80,10 +74,6 @@ fn can_specify_message_for_email() {
     assert!(res.is_err());
     let errs = res.unwrap_err().inner();
     assert!(errs.contains_key("val"));
-    if let ValidationErrorsKind::Field(ref err) = errs["val"] {
-        assert_eq!(err.len(), 1);
-        assert_eq!(err[0].clone().message.unwrap(), "oops");
-    } else {
-        panic!("Expected field validation errors");
-    }
+    assert_eq!(errs["val"].len(), 1);
+    assert_eq!(errs["val"][0].clone().message.unwrap(), "oops");
 }

--- a/validator_derive/tests/length.rs
+++ b/validator_derive/tests/length.rs
@@ -1,5 +1,3 @@
-#![allow(deprecated)]
-
 #[macro_use]
 extern crate validator_derive;
 extern crate validator;
@@ -34,7 +32,7 @@ fn value_out_of_length_fails_validation() {
     };
     let res = s.validate();
     assert!(res.is_err());
-    let errs = res.unwrap_err().inner();
+    let errs = res.unwrap_err().field_errors();
     assert!(errs.contains_key("val"));
     assert_eq!(errs["val"].len(), 1);
     assert_eq!(errs["val"][0].code, "length");
@@ -55,7 +53,7 @@ fn can_specify_code_for_length() {
     };
     let res = s.validate();
     assert!(res.is_err());
-    let errs = res.unwrap_err().inner();
+    let errs = res.unwrap_err().field_errors();
     assert!(errs.contains_key("val"));
     assert_eq!(errs["val"].len(), 1);
     assert_eq!(errs["val"][0].code, "oops");
@@ -73,7 +71,7 @@ fn can_specify_message_for_length() {
     };
     let res = s.validate();
     assert!(res.is_err());
-    let errs = res.unwrap_err().inner();
+    let errs = res.unwrap_err().field_errors();
     assert!(errs.contains_key("val"));
     assert_eq!(errs["val"].len(), 1);
     assert_eq!(errs["val"][0].clone().message.unwrap(), "oops");

--- a/validator_derive/tests/length.rs
+++ b/validator_derive/tests/length.rs
@@ -1,8 +1,10 @@
+#![allow(deprecated)]
+
 #[macro_use]
 extern crate validator_derive;
 extern crate validator;
 
-use validator::{Validate, ValidationErrorsKind};
+use validator::Validate;
 
 #[test]
 fn can_validate_length_ok() {
@@ -34,15 +36,11 @@ fn value_out_of_length_fails_validation() {
     assert!(res.is_err());
     let errs = res.unwrap_err().inner();
     assert!(errs.contains_key("val"));
-    if let ValidationErrorsKind::Field(ref err) = errs["val"] {
-        assert_eq!(err.len(), 1);
-        assert_eq!(err[0].code, "length");
-        assert_eq!(err[0].params["value"], "");
-        assert_eq!(err[0].params["min"], 5);
-        assert_eq!(err[0].params["max"], 10);
-    } else {
-        panic!("Expected field validation errors");
-    }
+    assert_eq!(errs["val"].len(), 1);
+    assert_eq!(errs["val"][0].code, "length");
+    assert_eq!(errs["val"][0].params["value"], "");
+    assert_eq!(errs["val"][0].params["min"], 5);
+    assert_eq!(errs["val"][0].params["max"], 10);
 }
 
 #[test]
@@ -59,12 +57,8 @@ fn can_specify_code_for_length() {
     assert!(res.is_err());
     let errs = res.unwrap_err().inner();
     assert!(errs.contains_key("val"));
-    if let ValidationErrorsKind::Field(ref err) = errs["val"] {
-        assert_eq!(err.len(), 1);
-        assert_eq!(err[0].code, "oops");
-    } else {
-        panic!("Expected field validation errors");
-    }
+    assert_eq!(errs["val"].len(), 1);
+    assert_eq!(errs["val"][0].code, "oops");
 }
 
 #[test]
@@ -81,10 +75,6 @@ fn can_specify_message_for_length() {
     assert!(res.is_err());
     let errs = res.unwrap_err().inner();
     assert!(errs.contains_key("val"));
-    if let ValidationErrorsKind::Field(ref err) = errs["val"] {
-        assert_eq!(err.len(), 1);
-        assert_eq!(err[0].clone().message.unwrap(), "oops");
-    } else {
-        panic!("Expected field validation errors");
-    }
+    assert_eq!(errs["val"].len(), 1);
+    assert_eq!(errs["val"][0].clone().message.unwrap(), "oops");
 }

--- a/validator_derive/tests/length.rs
+++ b/validator_derive/tests/length.rs
@@ -2,7 +2,7 @@
 extern crate validator_derive;
 extern crate validator;
 
-use validator::Validate;
+use validator::{Validate, ValidationErrorsKind};
 
 #[test]
 fn can_validate_length_ok() {
@@ -34,11 +34,15 @@ fn value_out_of_length_fails_validation() {
     assert!(res.is_err());
     let errs = res.unwrap_err().inner();
     assert!(errs.contains_key("val"));
-    assert_eq!(errs["val"].len(), 1);
-    assert_eq!(errs["val"][0].code, "length");
-    assert_eq!(errs["val"][0].params["value"], "");
-    assert_eq!(errs["val"][0].params["min"], 5);
-    assert_eq!(errs["val"][0].params["max"], 10);
+    if let ValidationErrorsKind::Field(ref err) = errs["val"] {
+        assert_eq!(err.len(), 1);
+        assert_eq!(err[0].code, "length");
+        assert_eq!(err[0].params["value"], "");
+        assert_eq!(err[0].params["min"], 5);
+        assert_eq!(err[0].params["max"], 10);
+    } else {
+        panic!("Expected field validation errors");
+    }
 }
 
 #[test]
@@ -55,8 +59,12 @@ fn can_specify_code_for_length() {
     assert!(res.is_err());
     let errs = res.unwrap_err().inner();
     assert!(errs.contains_key("val"));
-    assert_eq!(errs["val"].len(), 1);
-    assert_eq!(errs["val"][0].code, "oops");
+    if let ValidationErrorsKind::Field(ref err) = errs["val"] {
+        assert_eq!(err.len(), 1);
+        assert_eq!(err[0].code, "oops");
+    } else {
+        panic!("Expected field validation errors");
+    }
 }
 
 #[test]
@@ -73,6 +81,10 @@ fn can_specify_message_for_length() {
     assert!(res.is_err());
     let errs = res.unwrap_err().inner();
     assert!(errs.contains_key("val"));
-    assert_eq!(errs["val"].len(), 1);
-    assert_eq!(errs["val"][0].clone().message.unwrap(), "oops");
+    if let ValidationErrorsKind::Field(ref err) = errs["val"] {
+        assert_eq!(err.len(), 1);
+        assert_eq!(err[0].clone().message.unwrap(), "oops");
+    } else {
+        panic!("Expected field validation errors");
+    }
 }

--- a/validator_derive/tests/must_match.rs
+++ b/validator_derive/tests/must_match.rs
@@ -1,8 +1,10 @@
+#![allow(deprecated)]
+
 #[macro_use]
 extern crate validator_derive;
 extern crate validator;
 
-use validator::{Validate, ValidationErrorsKind};
+use validator::Validate;
 
 
 #[test]
@@ -40,14 +42,10 @@ fn not_matching_fails_validation() {
     assert!(res.is_err());
     let errs = res.unwrap_err().inner();
     assert!(errs.contains_key("val"));
-    if let ValidationErrorsKind::Field(ref err) = errs["val"] {
-        assert_eq!(err.len(), 1);
-        assert_eq!(err[0].code, "must_match");
-        assert_eq!(err[0].params["value"], "bob");
-        assert_eq!(err[0].params["other"], "bobby");
-    } else {
-        panic!("Expected field validation errors");
-    }
+    assert_eq!(errs["val"].len(), 1);
+    assert_eq!(errs["val"][0].code, "must_match");
+    assert_eq!(errs["val"][0].params["value"], "bob");
+    assert_eq!(errs["val"][0].params["other"], "bobby");
 }
 
 #[test]
@@ -66,12 +64,8 @@ fn can_specify_code_for_must_match() {
     assert!(res.is_err());
     let errs = res.unwrap_err().inner();
     assert!(errs.contains_key("val"));
-    if let ValidationErrorsKind::Field(ref err) = errs["val"] {
-        assert_eq!(err.len(), 1);
-        assert_eq!(err[0].code, "oops");
-    } else {
-        panic!("Expected field validation errors");
-    }
+    assert_eq!(errs["val"].len(), 1);
+    assert_eq!(errs["val"][0].code, "oops");
 }
 
 #[test]
@@ -90,10 +84,6 @@ fn can_specify_message_for_must_match() {
     assert!(res.is_err());
     let errs = res.unwrap_err().inner();
     assert!(errs.contains_key("val"));
-    if let ValidationErrorsKind::Field(ref err) = errs["val"] {
-        assert_eq!(err.len(), 1);
-        assert_eq!(err[0].clone().message.unwrap(), "oops");
-    } else {
-        panic!("Expected field validation errors");
-    }
+    assert_eq!(errs["val"].len(), 1);
+    assert_eq!(errs["val"][0].clone().message.unwrap(), "oops");
 }

--- a/validator_derive/tests/must_match.rs
+++ b/validator_derive/tests/must_match.rs
@@ -2,7 +2,7 @@
 extern crate validator_derive;
 extern crate validator;
 
-use validator::Validate;
+use validator::{Validate, ValidationErrorsKind};
 
 
 #[test]
@@ -40,10 +40,14 @@ fn not_matching_fails_validation() {
     assert!(res.is_err());
     let errs = res.unwrap_err().inner();
     assert!(errs.contains_key("val"));
-    assert_eq!(errs["val"].len(), 1);
-    assert_eq!(errs["val"][0].code, "must_match");
-    assert_eq!(errs["val"][0].params["value"], "bob");
-    assert_eq!(errs["val"][0].params["other"], "bobby");
+    if let ValidationErrorsKind::Field(ref err) = errs["val"] {
+        assert_eq!(err.len(), 1);
+        assert_eq!(err[0].code, "must_match");
+        assert_eq!(err[0].params["value"], "bob");
+        assert_eq!(err[0].params["other"], "bobby");
+    } else {
+        panic!("Expected field validation errors");
+    }
 }
 
 #[test]
@@ -62,8 +66,12 @@ fn can_specify_code_for_must_match() {
     assert!(res.is_err());
     let errs = res.unwrap_err().inner();
     assert!(errs.contains_key("val"));
-    assert_eq!(errs["val"].len(), 1);
-    assert_eq!(errs["val"][0].code, "oops");
+    if let ValidationErrorsKind::Field(ref err) = errs["val"] {
+        assert_eq!(err.len(), 1);
+        assert_eq!(err[0].code, "oops");
+    } else {
+        panic!("Expected field validation errors");
+    }
 }
 
 #[test]
@@ -82,6 +90,10 @@ fn can_specify_message_for_must_match() {
     assert!(res.is_err());
     let errs = res.unwrap_err().inner();
     assert!(errs.contains_key("val"));
-    assert_eq!(errs["val"].len(), 1);
-    assert_eq!(errs["val"][0].clone().message.unwrap(), "oops");
+    if let ValidationErrorsKind::Field(ref err) = errs["val"] {
+        assert_eq!(err.len(), 1);
+        assert_eq!(err[0].clone().message.unwrap(), "oops");
+    } else {
+        panic!("Expected field validation errors");
+    }
 }

--- a/validator_derive/tests/must_match.rs
+++ b/validator_derive/tests/must_match.rs
@@ -1,5 +1,3 @@
-#![allow(deprecated)]
-
 #[macro_use]
 extern crate validator_derive;
 extern crate validator;
@@ -40,7 +38,7 @@ fn not_matching_fails_validation() {
 
     let res = s.validate();
     assert!(res.is_err());
-    let errs = res.unwrap_err().inner();
+    let errs = res.unwrap_err().field_errors();
     assert!(errs.contains_key("val"));
     assert_eq!(errs["val"].len(), 1);
     assert_eq!(errs["val"][0].code, "must_match");
@@ -62,7 +60,7 @@ fn can_specify_code_for_must_match() {
     };
     let res = s.validate();
     assert!(res.is_err());
-    let errs = res.unwrap_err().inner();
+    let errs = res.unwrap_err().field_errors();
     assert!(errs.contains_key("val"));
     assert_eq!(errs["val"].len(), 1);
     assert_eq!(errs["val"][0].code, "oops");
@@ -82,7 +80,7 @@ fn can_specify_message_for_must_match() {
     };
     let res = s.validate();
     assert!(res.is_err());
-    let errs = res.unwrap_err().inner();
+    let errs = res.unwrap_err().field_errors();
     assert!(errs.contains_key("val"));
     assert_eq!(errs["val"].len(), 1);
     assert_eq!(errs["val"][0].clone().message.unwrap(), "oops");

--- a/validator_derive/tests/nested.rs
+++ b/validator_derive/tests/nested.rs
@@ -1,8 +1,11 @@
 #[macro_use]
 extern crate validator_derive;
 extern crate validator;
+#[macro_use]
+extern crate serde_derive;
 
-use validator::Validate;
+use validator::{validate_length, Validate, ValidationError, ValidationErrors, ValidationErrorsKind, Validator};
+use std::{borrow::Cow, collections::HashMap};
 
 #[derive(Debug, Validate)]
 struct Root<'a> {
@@ -35,18 +38,13 @@ struct ParentWithOptionalChild {
 }
 
 #[derive(Debug, Validate)]
-struct ParentWithLifetimeAndOptionalChild<'a> {
-    #[validate]
-    child: Option<&'a Child>,
-}
-
-#[derive(Debug, Validate)]
 struct ParentWithVectorOfChildren {
     #[validate]
+    #[validate(length(min = "1"))]
     child: Vec<Child>,
 }
 
-#[derive(Debug, Validate)]
+#[derive(Debug, Validate, Serialize)]
 struct Child {
     #[validate(length(min = "1"))]
     value: String,
@@ -82,19 +80,44 @@ fn failed_validation_points_to_original_field_names() {
     let res = root.validate();
     assert!(res.is_err());
     let errs = res.unwrap_err().inner();
-    assert_eq!(errs.len(), 3);
+    assert_eq!(errs.len(), 2);
     assert!(errs.contains_key("value"));
-    assert_eq!(errs["value"].len(), 1);
-    assert_eq!(errs["value"][0].path, vec!["value"]);
-    assert_eq!(errs["value"][0].code, "length");
-    assert!(errs.contains_key("a.value"));
-    assert_eq!(errs["a.value"].len(), 1);
-    assert_eq!(errs["a.value"][0].path, vec!["a", "value"]);
-    assert_eq!(errs["a.value"][0].code, "length");
-    assert!(errs.contains_key("a.b.value"));
-    assert_eq!(errs["a.b.value"].len(), 1);
-    assert_eq!(errs["a.b.value"][0].path, vec!["a", "b", "value"]);
-    assert_eq!(errs["a.b.value"][0].code, "length");
+    if let ValidationErrorsKind::Field(ref errs) = errs["value"] {
+        assert_eq!(errs.len(), 1);
+        assert_eq!(errs[0].code, "length");
+    } else {
+        panic!("Expected field validation errors");
+    }
+    assert!(errs.contains_key("a"));
+    if let ValidationErrorsKind::Struct(ref errs) = errs["a"] {
+        unwrap_map(errs, |errs| {
+            assert_eq!(errs.len(), 2);
+            assert!(errs.contains_key("value"));
+            if let ValidationErrorsKind::Field(ref errs) = errs["value"] {
+                assert_eq!(errs.len(), 1);
+                assert_eq!(errs[0].code, "length");
+            } else {
+                panic!("Expected field validation errors");
+            }
+            assert!(errs.contains_key("b"));
+            if let ValidationErrorsKind::Struct(ref errs) = errs["b"] {
+                unwrap_map(errs, |errs| {
+                    assert_eq!(errs.len(), 1);
+                    assert!(errs.contains_key("value"));
+                    if let ValidationErrorsKind::Field(ref errs) = errs["value"] {
+                        assert_eq!(errs.len(), 1);
+                        assert_eq!(errs[0].code, "length");
+                    } else {
+                        panic!("Expected field validation errors");
+                    }
+                });
+            } else {
+                panic!("Expected struct validation errors");
+            }
+        });
+    } else {
+        panic!("Expected struct validation errors");
+    }
 }
 
 #[test]
@@ -109,14 +132,31 @@ fn test_can_validate_option_fields_without_lifetime() {
     assert!(res.is_err());
     let errs = res.unwrap_err().inner();
     assert_eq!(errs.len(), 1);
-    assert!(errs.contains_key("child.value"));
-    assert_eq!(errs["child.value"].len(), 1);
-    assert_eq!(errs["child.value"][0].path, vec!["child", "value"]);
-    assert_eq!(errs["child.value"][0].code, "length");
+    assert!(errs.contains_key("child"));
+    if let ValidationErrorsKind::Struct(ref errs) = errs["child"] {
+        unwrap_map(errs, |errs| {
+            assert_eq!(errs.len(), 1);
+            assert!(errs.contains_key("value"));
+            if let ValidationErrorsKind::Field(ref errs) = errs["value"] {
+                assert_eq!(errs.len(), 1);
+                assert_eq!(errs[0].code, "length");
+            } else {
+                panic!("Expected field validation errors");
+            }
+        });
+    } else {
+        panic!("Expected struct validation errors");
+    }
 }
 
 #[test]
 fn test_can_validate_option_fields_with_lifetime() {
+    #[derive(Debug, Validate)]
+    struct ParentWithLifetimeAndOptionalChild<'a> {
+        #[validate]
+        child: Option<&'a Child>,
+    }
+
     let child = Child {
         value: String::new(),
     };
@@ -129,10 +169,21 @@ fn test_can_validate_option_fields_with_lifetime() {
     assert!(res.is_err());
     let errs = res.unwrap_err().inner();
     assert_eq!(errs.len(), 1);
-    assert!(errs.contains_key("child.value"));
-    assert_eq!(errs["child.value"].len(), 1);
-    assert_eq!(errs["child.value"][0].path, vec!["child", "value"]);
-    assert_eq!(errs["child.value"][0].code, "length");
+    assert!(errs.contains_key("child"));
+    if let ValidationErrorsKind::Struct(ref errs) = errs["child"] {
+        unwrap_map(errs, |errs| {
+            assert_eq!(errs.len(), 1);
+            assert!(errs.contains_key("value"));
+            if let ValidationErrorsKind::Field(ref errs) = errs["value"] {
+                assert_eq!(errs.len(), 1);
+                assert_eq!(errs[0].code, "length");
+            } else {
+                panic!("Expected field validation errors");
+            }
+        });
+    } else {
+        panic!("Expected struct validation errors");
+    }
 }
 
 #[test]
@@ -167,13 +218,153 @@ fn test_can_validate_vector_fields() {
     let res = instance.validate();
     assert!(res.is_err());
     let errs = res.unwrap_err().inner();
-    assert_eq!(errs.len(), 2);
-    assert!(errs.contains_key("child.1.value"));
-    assert_eq!(errs["child.1.value"].len(), 1);
-    assert_eq!(errs["child.1.value"][0].path, vec!["child", "1", "value"]);
-    assert_eq!(errs["child.1.value"][0].code, "length");
-    assert!(errs.contains_key("child.3.value"));
-    assert_eq!(errs["child.3.value"].len(), 1);
-    assert_eq!(errs["child.3.value"][0].path, vec!["child", "3", "value"]);
-    assert_eq!(errs["child.3.value"][0].code, "length");
+    assert_eq!(errs.len(), 1);
+    assert!(errs.contains_key("child"));
+    if let ValidationErrorsKind::List(ref errs) = errs["child"] {
+        assert!(errs.contains_key(&1));
+        unwrap_map(&errs[&1], |errs| {
+            assert_eq!(errs.len(), 1);
+            assert!(errs.contains_key("value"));
+            if let ValidationErrorsKind::Field(ref errs) = errs["value"] {
+                assert_eq!(errs.len(), 1);
+                assert_eq!(errs[0].code, "length");
+            } else {
+                panic!("Expected field validation errors");
+            }
+        });
+        assert!(errs.contains_key(&3));
+        unwrap_map(&errs[&3], |errs| {
+            assert_eq!(errs.len(), 1);
+            assert!(errs.contains_key("value"));
+            if let ValidationErrorsKind::Field(ref errs) = errs["value"] {
+                assert_eq!(errs.len(), 1);
+                assert_eq!(errs[0].code, "length");
+            } else {
+                panic!("Expected field validation errors");
+            }
+        });
+    } else {
+        panic!("Expected list validation errors");
+    }
+}
+
+#[test]
+fn test_field_validations_take_priority_over_nested_validations() {
+    let instance = ParentWithVectorOfChildren {
+        child: Vec::new(),
+    };
+
+    let res = instance.validate();
+    assert!(res.is_err());
+    let errs = res.unwrap_err().inner();
+    assert_eq!(errs.len(), 1);
+    assert!(errs.contains_key("child"));
+    if let ValidationErrorsKind::Field(ref errs) = errs["child"] {
+        assert_eq!(errs.len(), 1);
+        assert_eq!(errs[0].code, "length");
+    } else {
+        panic!("Expected field validation errors");
+    }
+}
+
+#[test]
+#[should_panic(expected = "Attempt to replace non-empty ValidationErrors entry")]
+#[allow(unused)]
+fn test_field_validation_errors_replaced_with_nested_validations_fails() {
+
+    #[derive(Debug)]
+    struct ParentWithOverridingStructValidations {
+        child: Vec<Child>,
+    }
+
+    impl Validate for ParentWithOverridingStructValidations {
+        // Evaluating structs after fields validations have discovered errors should fail because
+        // field validations are expected to take priority over nested struct validations
+        #[allow(unused_mut)]
+        fn validate(&self) -> Result<(), ValidationErrors> {
+            // First validate the length of the vector:
+            let mut errors = ValidationErrors::new();
+            if !validate_length(Validator::Length { min: Some(2u64), max: None, equal: None }, &self.child) {
+                let mut err = ValidationError::new("length");
+                err.add_param(Cow::from("min"), &2u64);
+                err.add_param(Cow::from("value"), &&self.child);
+                errors.add("child", err);
+            }
+
+            // Then validate the nested vector of structs without checking for existing field errors:
+            let mut result = if errors.is_empty() { Ok(()) } else { Err(errors) };
+            {
+                let results: Vec<_> = self.child.iter().map(|child| {
+                    let mut result = Ok(());
+                    result = ValidationErrors::merge(result, "child", child.validate());
+                    result
+                }).collect();
+                result = ValidationErrors::merge_all(result, "child", results);
+            }
+            result
+        }
+    }
+
+    let instance = ParentWithOverridingStructValidations {
+        child: vec![
+            Child {
+                value: String::new()
+            }]
+    };
+    instance.validate();
+}
+
+#[test]
+#[should_panic(expected = "Attempt to add field validation to a non-Field ValidationErrorsKind instance")]
+#[allow(unused)]
+fn test_field_validations_evaluated_after_nested_validations_fails() {
+    #[derive(Debug)]
+    struct ParentWithStructValidationsFirst {
+        child: Vec<Child>,
+    }
+
+    impl Validate for ParentWithStructValidationsFirst {
+        // Evaluating fields after their nested structs should fail because field
+        // validations are expected to take priority over nested struct validations
+        #[allow(unused_mut)]
+        fn validate(&self) -> Result<(), ValidationErrors> {
+            // First validate the nested vector of structs:
+            let mut result = Ok(());
+            if !ValidationErrors::has_error(&result, "child") {
+                let results: Vec<_> = self.child.iter().map(|child| {
+                    let mut result = Ok(());
+                    result = ValidationErrors::merge(result, "child", child.validate());
+                    result
+                }).collect();
+                result = ValidationErrors::merge_all(result, "child", results);
+            }
+
+            // Then validate the length of the vector itself:
+            if !validate_length(Validator::Length { min: Some(2u64), max: None, equal: None }, &self.child) {
+                let mut err = ValidationError::new("length");
+                err.add_param(Cow::from("min"), &2u64);
+                err.add_param(Cow::from("value"), &&self.child);
+                result = result.and_then(|_| Err(ValidationErrors::new())).map_err(|mut errors| {
+                    errors.add("child", err);
+                    errors
+                });
+            }
+            result
+        }
+    }
+
+    let instance = ParentWithStructValidationsFirst {
+        child: vec![
+            Child {
+                value: String::new()
+            }]
+    };
+    let res = instance.validate();
+}
+
+fn unwrap_map<F>(errors: &Box<ValidationErrors>, f: F)
+    where F: FnOnce(HashMap<&'static str, ValidationErrorsKind>)
+{
+    let errors = *errors.clone();
+    f(errors.inner());
 }

--- a/validator_derive/tests/nested.rs
+++ b/validator_derive/tests/nested.rs
@@ -1,0 +1,44 @@
+#[macro_use]
+extern crate validator_derive;
+extern crate validator;
+
+use validator::Validate;
+
+#[derive(Debug, Validate)]
+struct Root {
+    #[validate]
+    nested: Nested,
+}
+
+#[derive(Debug, Validate)]
+struct Nested {
+    #[validate(length(min = "1"))]
+    value: String,
+}
+
+#[test]
+fn is_fine_with_nested_validations() {
+    let root = Root {
+        nested: Nested {
+            value: "Something".to_string(),
+        }
+    };
+
+    assert!(root.validate().is_ok());
+}
+
+#[test]
+fn failed_validation_points_to_original_field_names() {
+    let root = Root {
+        nested: Nested {
+            value: "".to_string(),
+        }
+    };
+
+    let res = root.validate();
+    assert!(res.is_err());
+    let errs = res.unwrap_err().inner();
+    assert!(errs.contains_key("value"));
+    assert_eq!(errs["value"].len(), 1);
+    assert_eq!(errs["value"][0].code, "length");
+}

--- a/validator_derive/tests/nested.rs
+++ b/validator_derive/tests/nested.rs
@@ -79,7 +79,7 @@ fn failed_validation_points_to_original_field_names() {
 
     let res = root.validate();
     assert!(res.is_err());
-    let errs = res.unwrap_err().inner();
+    let errs = res.unwrap_err().errors();
     assert_eq!(errs.len(), 2);
     assert!(errs.contains_key("value"));
     if let ValidationErrorsKind::Field(ref errs) = errs["value"] {
@@ -130,7 +130,7 @@ fn test_can_validate_option_fields_without_lifetime() {
 
     let res = instance.validate();
     assert!(res.is_err());
-    let errs = res.unwrap_err().inner();
+    let errs = res.unwrap_err().errors();
     assert_eq!(errs.len(), 1);
     assert!(errs.contains_key("child"));
     if let ValidationErrorsKind::Struct(ref errs) = errs["child"] {
@@ -167,7 +167,7 @@ fn test_can_validate_option_fields_with_lifetime() {
 
     let res = instance.validate();
     assert!(res.is_err());
-    let errs = res.unwrap_err().inner();
+    let errs = res.unwrap_err().errors();
     assert_eq!(errs.len(), 1);
     assert!(errs.contains_key("child"));
     if let ValidationErrorsKind::Struct(ref errs) = errs["child"] {
@@ -217,7 +217,7 @@ fn test_can_validate_vector_fields() {
 
     let res = instance.validate();
     assert!(res.is_err());
-    let errs = res.unwrap_err().inner();
+    let errs = res.unwrap_err().errors();
     assert_eq!(errs.len(), 1);
     assert!(errs.contains_key("child"));
     if let ValidationErrorsKind::List(ref errs) = errs["child"] {
@@ -256,7 +256,7 @@ fn test_field_validations_take_priority_over_nested_validations() {
 
     let res = instance.validate();
     assert!(res.is_err());
-    let errs = res.unwrap_err().inner();
+    let errs = res.unwrap_err().errors();
     assert_eq!(errs.len(), 1);
     assert!(errs.contains_key("child"));
     if let ValidationErrorsKind::Field(ref errs) = errs["child"] {
@@ -366,5 +366,5 @@ fn unwrap_map<F>(errors: &Box<ValidationErrors>, f: F)
     where F: FnOnce(HashMap<&'static str, ValidationErrorsKind>)
 {
     let errors = *errors.clone();
-    f(errors.inner());
+    f(errors.errors());
 }

--- a/validator_derive/tests/nested.rs
+++ b/validator_derive/tests/nested.rs
@@ -5,13 +5,25 @@ extern crate validator;
 use validator::Validate;
 
 #[derive(Debug, Validate)]
-struct Root {
+struct Root<'a> {
+    #[validate(length(min = "1"))]
+    value: String,
+
     #[validate]
-    nested: Nested,
+    a: &'a A,
 }
 
 #[derive(Debug, Validate)]
-struct Nested {
+struct A {
+    #[validate(length(min = "1"))]
+    value: String,
+
+    #[validate]
+    b: B,
+}
+
+#[derive(Debug, Validate)]
+struct B {
     #[validate(length(min = "1"))]
     value: String,
 }
@@ -19,8 +31,12 @@ struct Nested {
 #[test]
 fn is_fine_with_nested_validations() {
     let root = Root {
-        nested: Nested {
-            value: "Something".to_string(),
+        value: "valid".to_string(),
+        a: &A {
+            value: "valid".to_string(),
+            b: B {
+                value: "valid".to_string(),
+            }
         }
     };
 
@@ -30,15 +46,29 @@ fn is_fine_with_nested_validations() {
 #[test]
 fn failed_validation_points_to_original_field_names() {
     let root = Root {
-        nested: Nested {
+        value: "".to_string(),
+        a: &A {
             value: "".to_string(),
+            b: B {
+                value: "".to_string(),
+            }
         }
     };
 
     let res = root.validate();
     assert!(res.is_err());
     let errs = res.unwrap_err().inner();
+    assert_eq!(errs.len(), 3);
     assert!(errs.contains_key("value"));
     assert_eq!(errs["value"].len(), 1);
+    assert_eq!(errs["value"][0].path, vec!["value"]);
     assert_eq!(errs["value"][0].code, "length");
+    assert!(errs.contains_key("a.value"));
+    assert_eq!(errs["a.value"].len(), 1);
+    assert_eq!(errs["a.value"][0].path, vec!["a", "value"]);
+    assert_eq!(errs["a.value"][0].code, "length");
+    assert!(errs.contains_key("a.b.value"));
+    assert_eq!(errs["a.b.value"].len(), 1);
+    assert_eq!(errs["a.b.value"][0].path, vec!["a", "b", "value"]);
+    assert_eq!(errs["a.b.value"][0].code, "length");
 }

--- a/validator_derive/tests/nested.rs
+++ b/validator_derive/tests/nested.rs
@@ -168,12 +168,12 @@ fn test_can_validate_vector_fields() {
     assert!(res.is_err());
     let errs = res.unwrap_err().inner();
     assert_eq!(errs.len(), 2);
-    assert!(errs.contains_key("child[1].value"));
-    assert_eq!(errs["child[1].value"].len(), 1);
-    assert_eq!(errs["child[1].value"][0].path, vec!["child[1]", "value"]);
-    assert_eq!(errs["child[1].value"][0].code, "length");
-    assert!(errs.contains_key("child[3].value"));
-    assert_eq!(errs["child[3].value"].len(), 1);
-    assert_eq!(errs["child[3].value"][0].path, vec!["child[3]", "value"]);
-    assert_eq!(errs["child[3].value"][0].code, "length");
+    assert!(errs.contains_key("child.1.value"));
+    assert_eq!(errs["child.1.value"].len(), 1);
+    assert_eq!(errs["child.1.value"][0].path, vec!["child", "1", "value"]);
+    assert_eq!(errs["child.1.value"][0].code, "length");
+    assert!(errs.contains_key("child.3.value"));
+    assert_eq!(errs["child.3.value"].len(), 1);
+    assert_eq!(errs["child.3.value"][0].path, vec!["child", "3", "value"]);
+    assert_eq!(errs["child.3.value"][0].code, "length");
 }

--- a/validator_derive/tests/phone.rs
+++ b/validator_derive/tests/phone.rs
@@ -1,5 +1,3 @@
-#![allow(deprecated)]
-
 #[macro_use]
 extern crate validator_derive;
 extern crate validator;
@@ -37,7 +35,7 @@ fn bad_phone_fails_validation() {
     };
     let res = s.validate();
     assert!(res.is_err());
-    let errs = res.unwrap_err().inner();
+    let errs = res.unwrap_err().field_errors();
     assert!(errs.contains_key("val"));
     assert_eq!(errs["val"].len(), 1);
     assert_eq!(errs["val"][0].code, "phone");
@@ -56,7 +54,7 @@ fn can_specify_code_for_phone() {
     };
     let res = s.validate();
     assert!(res.is_err());
-    let errs = res.unwrap_err().inner();
+    let errs = res.unwrap_err().field_errors();
     assert!(errs.contains_key("val"));
     assert_eq!(errs["val"].len(), 1);
     assert_eq!(errs["val"][0].code, "oops");
@@ -76,7 +74,7 @@ fn can_specify_message_for_phone() {
     };
     let res = s.validate();
     assert!(res.is_err());
-    let errs = res.unwrap_err().inner();
+    let errs = res.unwrap_err().field_errors();
     assert!(errs.contains_key("val"));
     assert_eq!(errs["val"].len(), 1);
     assert_eq!(errs["val"][0].clone().message.unwrap(), "oops");

--- a/validator_derive/tests/phone.rs
+++ b/validator_derive/tests/phone.rs
@@ -2,7 +2,7 @@
 extern crate validator_derive;
 extern crate validator;
 
-use validator::Validate;
+use validator::{Validate, ValidationErrorsKind};
 
 
 #[cfg(feature = "phone")]
@@ -37,8 +37,12 @@ fn bad_phone_fails_validation() {
     assert!(res.is_err());
     let errs = res.unwrap_err().inner();
     assert!(errs.contains_key("val"));
-    assert_eq!(errs["val"].len(), 1);
-    assert_eq!(errs["val"][0].code, "phone");
+    if let ValidationErrorsKind::Field(ref err) = errs["val"] {
+        assert_eq!(err.len(), 1);
+        assert_eq!(err[0].code, "phone");
+    } else {
+        panic!("Expected field validation errors");
+    }
 }
 
 #[cfg(feature = "phone")]
@@ -56,9 +60,13 @@ fn can_specify_code_for_phone() {
     assert!(res.is_err());
     let errs = res.unwrap_err().inner();
     assert!(errs.contains_key("val"));
-    assert_eq!(errs["val"].len(), 1);
-    assert_eq!(errs["val"][0].code, "oops");
-    assert_eq!(errs["val"][0].params["value"], "bob");
+    if let ValidationErrorsKind::Field(ref err) = errs["val"] {
+        assert_eq!(err.len(), 1);
+        assert_eq!(err[0].code, "oops");
+        assert_eq!(err[0].params["value"], "bob");
+    } else {
+        panic!("Expected field validation errors");
+    }
 }
 
 #[cfg(feature = "phone")]
@@ -76,6 +84,10 @@ fn can_specify_message_for_phone() {
     assert!(res.is_err());
     let errs = res.unwrap_err().inner();
     assert!(errs.contains_key("val"));
-    assert_eq!(errs["val"].len(), 1);
-    assert_eq!(errs["val"][0].clone().message.unwrap(), "oops");
+    if let ValidationErrorsKind::Field(ref err) = errs["val"] {
+        assert_eq!(err.len(), 1);
+        assert_eq!(err[0].clone().message.unwrap(), "oops");
+    } else {
+        panic!("Expected field validation errors");
+    }
 }

--- a/validator_derive/tests/phone.rs
+++ b/validator_derive/tests/phone.rs
@@ -1,8 +1,10 @@
+#![allow(deprecated)]
+
 #[macro_use]
 extern crate validator_derive;
 extern crate validator;
 
-use validator::{Validate, ValidationErrorsKind};
+use validator::Validate;
 
 
 #[cfg(feature = "phone")]
@@ -37,12 +39,8 @@ fn bad_phone_fails_validation() {
     assert!(res.is_err());
     let errs = res.unwrap_err().inner();
     assert!(errs.contains_key("val"));
-    if let ValidationErrorsKind::Field(ref err) = errs["val"] {
-        assert_eq!(err.len(), 1);
-        assert_eq!(err[0].code, "phone");
-    } else {
-        panic!("Expected field validation errors");
-    }
+    assert_eq!(errs["val"].len(), 1);
+    assert_eq!(errs["val"][0].code, "phone");
 }
 
 #[cfg(feature = "phone")]
@@ -60,13 +58,9 @@ fn can_specify_code_for_phone() {
     assert!(res.is_err());
     let errs = res.unwrap_err().inner();
     assert!(errs.contains_key("val"));
-    if let ValidationErrorsKind::Field(ref err) = errs["val"] {
-        assert_eq!(err.len(), 1);
-        assert_eq!(err[0].code, "oops");
-        assert_eq!(err[0].params["value"], "bob");
-    } else {
-        panic!("Expected field validation errors");
-    }
+    assert_eq!(errs["val"].len(), 1);
+    assert_eq!(errs["val"][0].code, "oops");
+    assert_eq!(errs["val"][0].params["value"], "bob");
 }
 
 #[cfg(feature = "phone")]
@@ -84,10 +78,6 @@ fn can_specify_message_for_phone() {
     assert!(res.is_err());
     let errs = res.unwrap_err().inner();
     assert!(errs.contains_key("val"));
-    if let ValidationErrorsKind::Field(ref err) = errs["val"] {
-        assert_eq!(err.len(), 1);
-        assert_eq!(err[0].clone().message.unwrap(), "oops");
-    } else {
-        panic!("Expected field validation errors");
-    }
+    assert_eq!(errs["val"].len(), 1);
+    assert_eq!(errs["val"][0].clone().message.unwrap(), "oops");
 }

--- a/validator_derive/tests/range.rs
+++ b/validator_derive/tests/range.rs
@@ -1,5 +1,3 @@
-#![allow(deprecated)]
-
 #[macro_use]
 extern crate validator_derive;
 extern crate validator;
@@ -34,7 +32,7 @@ fn value_out_of_range_fails_validation() {
     };
     let res = s.validate();
     assert!(res.is_err());
-    let errs = res.unwrap_err().inner();
+    let errs = res.unwrap_err().field_errors();
     assert!(errs.contains_key("val"));
     assert_eq!(errs["val"].len(), 1);
     assert_eq!(errs["val"][0].code, "range");
@@ -52,7 +50,7 @@ fn can_specify_code_for_range() {
     };
     let res = s.validate();
     assert!(res.is_err());
-    let errs = res.unwrap_err().inner();
+    let errs = res.unwrap_err().field_errors();
     assert!(errs.contains_key("val"));
     assert_eq!(errs["val"].len(), 1);
     assert_eq!(errs["val"][0].code, "oops");
@@ -73,7 +71,7 @@ fn can_specify_message_for_range() {
     };
     let res = s.validate();
     assert!(res.is_err());
-    let errs = res.unwrap_err().inner();
+    let errs = res.unwrap_err().field_errors();
     assert!(errs.contains_key("val"));
     assert_eq!(errs["val"].len(), 1);
     assert_eq!(errs["val"][0].clone().message.unwrap(), "oops");

--- a/validator_derive/tests/range.rs
+++ b/validator_derive/tests/range.rs
@@ -1,8 +1,10 @@
+#![allow(deprecated)]
+
 #[macro_use]
 extern crate validator_derive;
 extern crate validator;
 
-use validator::{Validate, ValidationErrorsKind};
+use validator::Validate;
 
 #[test]
 fn can_validate_range_ok() {
@@ -34,12 +36,8 @@ fn value_out_of_range_fails_validation() {
     assert!(res.is_err());
     let errs = res.unwrap_err().inner();
     assert!(errs.contains_key("val"));
-    if let ValidationErrorsKind::Field(ref err) = errs["val"] {
-        assert_eq!(err.len(), 1);
-        assert_eq!(err[0].code, "range");
-    } else {
-        panic!("Expected field validation errors");
-    }
+    assert_eq!(errs["val"].len(), 1);
+    assert_eq!(errs["val"][0].code, "range");
 }
 
 #[test]
@@ -56,15 +54,11 @@ fn can_specify_code_for_range() {
     assert!(res.is_err());
     let errs = res.unwrap_err().inner();
     assert!(errs.contains_key("val"));
-    if let ValidationErrorsKind::Field(ref err) = errs["val"] {
-        assert_eq!(err.len(), 1);
-        assert_eq!(err[0].code, "oops");
-        assert_eq!(err[0].params["value"], 11);
-        assert_eq!(err[0].params["min"], 5f64);
-        assert_eq!(err[0].params["max"], 10f64);
-    } else {
-        panic!("Expected field validation errors");
-    }
+    assert_eq!(errs["val"].len(), 1);
+    assert_eq!(errs["val"][0].code, "oops");
+    assert_eq!(errs["val"][0].params["value"], 11);
+    assert_eq!(errs["val"][0].params["min"], 5f64);
+    assert_eq!(errs["val"][0].params["max"], 10f64);
 }
 
 #[test]
@@ -81,10 +75,6 @@ fn can_specify_message_for_range() {
     assert!(res.is_err());
     let errs = res.unwrap_err().inner();
     assert!(errs.contains_key("val"));
-    if let ValidationErrorsKind::Field(ref err) = errs["val"] {
-        assert_eq!(err.len(), 1);
-        assert_eq!(err[0].clone().message.unwrap(), "oops");
-    } else {
-        panic!("Expected field validation errors");
-    }
+    assert_eq!(errs["val"].len(), 1);
+    assert_eq!(errs["val"][0].clone().message.unwrap(), "oops");
 }

--- a/validator_derive/tests/range.rs
+++ b/validator_derive/tests/range.rs
@@ -2,7 +2,7 @@
 extern crate validator_derive;
 extern crate validator;
 
-use validator::Validate;
+use validator::{Validate, ValidationErrorsKind};
 
 #[test]
 fn can_validate_range_ok() {
@@ -34,8 +34,12 @@ fn value_out_of_range_fails_validation() {
     assert!(res.is_err());
     let errs = res.unwrap_err().inner();
     assert!(errs.contains_key("val"));
-    assert_eq!(errs["val"].len(), 1);
-    assert_eq!(errs["val"][0].code, "range");
+    if let ValidationErrorsKind::Field(ref err) = errs["val"] {
+        assert_eq!(err.len(), 1);
+        assert_eq!(err[0].code, "range");
+    } else {
+        panic!("Expected field validation errors");
+    }
 }
 
 #[test]
@@ -52,11 +56,15 @@ fn can_specify_code_for_range() {
     assert!(res.is_err());
     let errs = res.unwrap_err().inner();
     assert!(errs.contains_key("val"));
-    assert_eq!(errs["val"].len(), 1);
-    assert_eq!(errs["val"][0].code, "oops");
-    assert_eq!(errs["val"][0].params["value"], 11);
-    assert_eq!(errs["val"][0].params["min"], 5f64);
-    assert_eq!(errs["val"][0].params["max"], 10f64);
+    if let ValidationErrorsKind::Field(ref err) = errs["val"] {
+        assert_eq!(err.len(), 1);
+        assert_eq!(err[0].code, "oops");
+        assert_eq!(err[0].params["value"], 11);
+        assert_eq!(err[0].params["min"], 5f64);
+        assert_eq!(err[0].params["max"], 10f64);
+    } else {
+        panic!("Expected field validation errors");
+    }
 }
 
 #[test]
@@ -73,6 +81,10 @@ fn can_specify_message_for_range() {
     assert!(res.is_err());
     let errs = res.unwrap_err().inner();
     assert!(errs.contains_key("val"));
-    assert_eq!(errs["val"].len(), 1);
-    assert_eq!(errs["val"][0].clone().message.unwrap(), "oops");
+    if let ValidationErrorsKind::Field(ref err) = errs["val"] {
+        assert_eq!(err.len(), 1);
+        assert_eq!(err[0].clone().message.unwrap(), "oops");
+    } else {
+        panic!("Expected field validation errors");
+    }
 }

--- a/validator_derive/tests/regex.rs
+++ b/validator_derive/tests/regex.rs
@@ -1,5 +1,3 @@
-#![allow(deprecated)]
-
 extern crate regex;
 #[macro_use]
 extern crate lazy_static;
@@ -42,7 +40,7 @@ fn bad_value_for_regex_fails_validation() {
     };
     let res = s.validate();
     assert!(res.is_err());
-    let errs = res.unwrap_err().inner();
+    let errs = res.unwrap_err().field_errors();
     assert!(errs.contains_key("val"));
     assert_eq!(errs["val"].len(), 1);
     assert_eq!(errs["val"][0].code, "regex");
@@ -61,7 +59,7 @@ fn can_specify_code_for_regex() {
     };
     let res = s.validate();
     assert!(res.is_err());
-    let errs = res.unwrap_err().inner();
+    let errs = res.unwrap_err().field_errors();
     assert!(errs.contains_key("val"));
     assert_eq!(errs["val"].len(), 1);
     assert_eq!(errs["val"][0].code, "oops");
@@ -79,7 +77,7 @@ fn can_specify_message_for_regex() {
     };
     let res = s.validate();
     assert!(res.is_err());
-    let errs = res.unwrap_err().inner();
+    let errs = res.unwrap_err().field_errors();
     assert!(errs.contains_key("val"));
     assert_eq!(errs["val"].len(), 1);
     assert_eq!(errs["val"][0].clone().message.unwrap(), "oops");

--- a/validator_derive/tests/regex.rs
+++ b/validator_derive/tests/regex.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 extern crate regex;
 #[macro_use]
 extern crate lazy_static;
@@ -5,7 +7,7 @@ extern crate lazy_static;
 extern crate validator_derive;
 extern crate validator;
 
-use validator::{Validate, ValidationErrorsKind};
+use validator::Validate;
 use regex::Regex;
 
 lazy_static! {
@@ -42,13 +44,9 @@ fn bad_value_for_regex_fails_validation() {
     assert!(res.is_err());
     let errs = res.unwrap_err().inner();
     assert!(errs.contains_key("val"));
-    if let ValidationErrorsKind::Field(ref err) = errs["val"] {
-        assert_eq!(err.len(), 1);
-        assert_eq!(err[0].code, "regex");
-        assert_eq!(err[0].params["value"], "2");
-    } else {
-        panic!("Expected field validation errors");
-    }
+    assert_eq!(errs["val"].len(), 1);
+    assert_eq!(errs["val"][0].code, "regex");
+    assert_eq!(errs["val"][0].params["value"], "2");
 }
 
 #[test]
@@ -65,12 +63,8 @@ fn can_specify_code_for_regex() {
     assert!(res.is_err());
     let errs = res.unwrap_err().inner();
     assert!(errs.contains_key("val"));
-    if let ValidationErrorsKind::Field(ref err) = errs["val"] {
-        assert_eq!(err.len(), 1);
-        assert_eq!(err[0].code, "oops");
-    } else {
-        panic!("Expected field validation errors");
-    }
+    assert_eq!(errs["val"].len(), 1);
+    assert_eq!(errs["val"][0].code, "oops");
 }
 
 #[test]
@@ -87,10 +81,6 @@ fn can_specify_message_for_regex() {
     assert!(res.is_err());
     let errs = res.unwrap_err().inner();
     assert!(errs.contains_key("val"));
-    if let ValidationErrorsKind::Field(ref err) = errs["val"] {
-        assert_eq!(err.len(), 1);
-        assert_eq!(err[0].clone().message.unwrap(), "oops");
-    } else {
-        panic!("Expected field validation errors");
-    }
+    assert_eq!(errs["val"].len(), 1);
+    assert_eq!(errs["val"][0].clone().message.unwrap(), "oops");
 }

--- a/validator_derive/tests/regex.rs
+++ b/validator_derive/tests/regex.rs
@@ -5,7 +5,7 @@ extern crate lazy_static;
 extern crate validator_derive;
 extern crate validator;
 
-use validator::Validate;
+use validator::{Validate, ValidationErrorsKind};
 use regex::Regex;
 
 lazy_static! {
@@ -42,9 +42,13 @@ fn bad_value_for_regex_fails_validation() {
     assert!(res.is_err());
     let errs = res.unwrap_err().inner();
     assert!(errs.contains_key("val"));
-    assert_eq!(errs["val"].len(), 1);
-    assert_eq!(errs["val"][0].code, "regex");
-    assert_eq!(errs["val"][0].params["value"], "2");
+    if let ValidationErrorsKind::Field(ref err) = errs["val"] {
+        assert_eq!(err.len(), 1);
+        assert_eq!(err[0].code, "regex");
+        assert_eq!(err[0].params["value"], "2");
+    } else {
+        panic!("Expected field validation errors");
+    }
 }
 
 #[test]
@@ -61,8 +65,12 @@ fn can_specify_code_for_regex() {
     assert!(res.is_err());
     let errs = res.unwrap_err().inner();
     assert!(errs.contains_key("val"));
-    assert_eq!(errs["val"].len(), 1);
-    assert_eq!(errs["val"][0].code, "oops");
+    if let ValidationErrorsKind::Field(ref err) = errs["val"] {
+        assert_eq!(err.len(), 1);
+        assert_eq!(err[0].code, "oops");
+    } else {
+        panic!("Expected field validation errors");
+    }
 }
 
 #[test]
@@ -79,6 +87,10 @@ fn can_specify_message_for_regex() {
     assert!(res.is_err());
     let errs = res.unwrap_err().inner();
     assert!(errs.contains_key("val"));
-    assert_eq!(errs["val"].len(), 1);
-    assert_eq!(errs["val"][0].clone().message.unwrap(), "oops");
+    if let ValidationErrorsKind::Field(ref err) = errs["val"] {
+        assert_eq!(err.len(), 1);
+        assert_eq!(err[0].clone().message.unwrap(), "oops");
+    } else {
+        panic!("Expected field validation errors");
+    }
 }

--- a/validator_derive/tests/schema.rs
+++ b/validator_derive/tests/schema.rs
@@ -1,5 +1,3 @@
-#![allow(deprecated)]
-
 #[macro_use]
 extern crate validator_derive;
 extern crate validator;
@@ -43,7 +41,7 @@ fn can_fail_schema_fn_validation() {
     };
     let res = s.validate();
     assert!(res.is_err());
-    let errs = res.unwrap_err().inner();
+    let errs = res.unwrap_err().field_errors();
     assert!(errs.contains_key("__all__"));
     assert_eq!(errs["__all__"].len(), 1);
     assert_eq!(errs["__all__"][0].code, "meh");
@@ -65,7 +63,7 @@ fn can_specify_message_for_schema_fn() {
     };
     let res = s.validate();
     assert!(res.is_err());
-    let errs = res.unwrap_err().inner();
+    let errs = res.unwrap_err().field_errors();
     assert!(errs.contains_key("__all__"));
     assert_eq!(errs["__all__"].len(), 1);
     assert_eq!(errs["__all__"][0].clone().message.unwrap(), "oops");
@@ -91,7 +89,7 @@ fn can_choose_to_run_schema_validation_even_after_field_errors() {
 
     let res = s.validate();
     assert!(res.is_err());
-    let errs = res.unwrap_err().inner();
+    let errs = res.unwrap_err().field_errors();
     assert!(errs.contains_key("__all__"));
     assert_eq!(errs["__all__"].len(), 1);
     assert_eq!(errs["__all__"][0].clone().code, "meh");

--- a/validator_derive/tests/schema.rs
+++ b/validator_derive/tests/schema.rs
@@ -1,8 +1,10 @@
+#![allow(deprecated)]
+
 #[macro_use]
 extern crate validator_derive;
 extern crate validator;
 
-use validator::{Validate, ValidationError, ValidationErrorsKind};
+use validator::{Validate, ValidationError};
 
 
 #[test]
@@ -43,12 +45,8 @@ fn can_fail_schema_fn_validation() {
     assert!(res.is_err());
     let errs = res.unwrap_err().inner();
     assert!(errs.contains_key("__all__"));
-    if let ValidationErrorsKind::Field(ref err) = errs["__all__"] {
-        assert_eq!(err.len(), 1);
-        assert_eq!(err[0].code, "meh");
-    } else {
-        panic!("Expected field validation errors");
-    }
+    assert_eq!(errs["__all__"].len(), 1);
+    assert_eq!(errs["__all__"][0].code, "meh");
 }
 
 #[test]
@@ -69,12 +67,8 @@ fn can_specify_message_for_schema_fn() {
     assert!(res.is_err());
     let errs = res.unwrap_err().inner();
     assert!(errs.contains_key("__all__"));
-    if let ValidationErrorsKind::Field(ref err) = errs["__all__"] {
-        assert_eq!(err.len(), 1);
-        assert_eq!(err[0].clone().message.unwrap(), "oops");
-    } else {
-        panic!("Expected field validation errors");
-    }
+    assert_eq!(errs["__all__"].len(), 1);
+    assert_eq!(errs["__all__"][0].clone().message.unwrap(), "oops");
 }
 
 #[test]
@@ -99,17 +93,9 @@ fn can_choose_to_run_schema_validation_even_after_field_errors() {
     assert!(res.is_err());
     let errs = res.unwrap_err().inner();
     assert!(errs.contains_key("__all__"));
-    if let ValidationErrorsKind::Field(ref err) = errs["__all__"] {
-        assert_eq!(err.len(), 1);
-        assert_eq!(err[0].clone().code, "meh");
-    } else {
-        panic!("Expected field validation errors");
-    }
+    assert_eq!(errs["__all__"].len(), 1);
+    assert_eq!(errs["__all__"][0].clone().code, "meh");
     assert!(errs.contains_key("num"));
-    if let ValidationErrorsKind::Field(ref err) = errs["num"] {
-        assert_eq!(err.len(), 1);
-        assert_eq!(err[0].clone().code, "range");
-    } else {
-        panic!("Expected field validation errors");
-    }
+    assert_eq!(errs["num"].len(), 1);
+    assert_eq!(errs["num"][0].clone().code, "range");
 }

--- a/validator_derive/tests/schema.rs
+++ b/validator_derive/tests/schema.rs
@@ -2,7 +2,7 @@
 extern crate validator_derive;
 extern crate validator;
 
-use validator::{Validate, ValidationError};
+use validator::{Validate, ValidationError, ValidationErrorsKind};
 
 
 #[test]
@@ -43,8 +43,12 @@ fn can_fail_schema_fn_validation() {
     assert!(res.is_err());
     let errs = res.unwrap_err().inner();
     assert!(errs.contains_key("__all__"));
-    assert_eq!(errs["__all__"].len(), 1);
-    assert_eq!(errs["__all__"][0].code, "meh");
+    if let ValidationErrorsKind::Field(ref err) = errs["__all__"] {
+        assert_eq!(err.len(), 1);
+        assert_eq!(err[0].code, "meh");
+    } else {
+        panic!("Expected field validation errors");
+    }
 }
 
 #[test]
@@ -65,8 +69,12 @@ fn can_specify_message_for_schema_fn() {
     assert!(res.is_err());
     let errs = res.unwrap_err().inner();
     assert!(errs.contains_key("__all__"));
-    assert_eq!(errs["__all__"].len(), 1);
-    assert_eq!(errs["__all__"][0].clone().message.unwrap(), "oops");
+    if let ValidationErrorsKind::Field(ref err) = errs["__all__"] {
+        assert_eq!(err.len(), 1);
+        assert_eq!(err[0].clone().message.unwrap(), "oops");
+    } else {
+        panic!("Expected field validation errors");
+    }
 }
 
 #[test]
@@ -91,9 +99,17 @@ fn can_choose_to_run_schema_validation_even_after_field_errors() {
     assert!(res.is_err());
     let errs = res.unwrap_err().inner();
     assert!(errs.contains_key("__all__"));
-    assert_eq!(errs["__all__"].len(), 1);
-    assert_eq!(errs["__all__"][0].clone().code, "meh");
+    if let ValidationErrorsKind::Field(ref err) = errs["__all__"] {
+        assert_eq!(err.len(), 1);
+        assert_eq!(err[0].clone().code, "meh");
+    } else {
+        panic!("Expected field validation errors");
+    }
     assert!(errs.contains_key("num"));
-    assert_eq!(errs["num"].len(), 1);
-    assert_eq!(errs["num"][0].clone().code, "range");
+    if let ValidationErrorsKind::Field(ref err) = errs["num"] {
+        assert_eq!(err.len(), 1);
+        assert_eq!(err[0].clone().code, "range");
+    } else {
+        panic!("Expected field validation errors");
+    }
 }

--- a/validator_derive/tests/url.rs
+++ b/validator_derive/tests/url.rs
@@ -2,7 +2,7 @@
 extern crate validator_derive;
 extern crate validator;
 
-use validator::Validate;
+use validator::{Validate, ValidationErrorsKind};
 
 
 #[test]
@@ -35,8 +35,12 @@ fn bad_url_fails_validation() {
     assert!(res.is_err());
     let errs = res.unwrap_err().inner();
     assert!(errs.contains_key("val"));
-    assert_eq!(errs["val"].len(), 1);
-    assert_eq!(errs["val"][0].code, "url");
+    if let ValidationErrorsKind::Field(ref err) = errs["val"] {
+        assert_eq!(err.len(), 1);
+        assert_eq!(err[0].code, "url");
+    } else {
+        panic!("Expected field validation errors");
+    }
 }
 
 #[test]
@@ -53,9 +57,13 @@ fn can_specify_code_for_url() {
     assert!(res.is_err());
     let errs = res.unwrap_err().inner();
     assert!(errs.contains_key("val"));
-    assert_eq!(errs["val"].len(), 1);
-    assert_eq!(errs["val"][0].code, "oops");
-    assert_eq!(errs["val"][0].params["value"], "bob");
+    if let ValidationErrorsKind::Field(ref err) = errs["val"] {
+        assert_eq!(err.len(), 1);
+        assert_eq!(err[0].code, "oops");
+        assert_eq!(err[0].params["value"], "bob");
+    } else {
+        panic!("Expected field validation errors");
+    }
 }
 
 #[test]
@@ -72,6 +80,10 @@ fn can_specify_message_for_url() {
     assert!(res.is_err());
     let errs = res.unwrap_err().inner();
     assert!(errs.contains_key("val"));
-    assert_eq!(errs["val"].len(), 1);
-    assert_eq!(errs["val"][0].clone().message.unwrap(), "oops");
+    if let ValidationErrorsKind::Field(ref err) = errs["val"] {
+        assert_eq!(err.len(), 1);
+        assert_eq!(err[0].clone().message.unwrap(), "oops");
+    } else {
+        panic!("Expected field validation errors");
+    }
 }

--- a/validator_derive/tests/url.rs
+++ b/validator_derive/tests/url.rs
@@ -1,5 +1,3 @@
-#![allow(deprecated)]
-
 #[macro_use]
 extern crate validator_derive;
 extern crate validator;
@@ -35,7 +33,7 @@ fn bad_url_fails_validation() {
     };
     let res = s.validate();
     assert!(res.is_err());
-    let errs = res.unwrap_err().inner();
+    let errs = res.unwrap_err().field_errors();
     assert!(errs.contains_key("val"));
     assert_eq!(errs["val"].len(), 1);
     assert_eq!(errs["val"][0].code, "url");
@@ -53,7 +51,7 @@ fn can_specify_code_for_url() {
     };
     let res = s.validate();
     assert!(res.is_err());
-    let errs = res.unwrap_err().inner();
+    let errs = res.unwrap_err().field_errors();
     assert!(errs.contains_key("val"));
     assert_eq!(errs["val"].len(), 1);
     assert_eq!(errs["val"][0].code, "oops");
@@ -72,7 +70,7 @@ fn can_specify_message_for_url() {
     };
     let res = s.validate();
     assert!(res.is_err());
-    let errs = res.unwrap_err().inner();
+    let errs = res.unwrap_err().field_errors();
     assert!(errs.contains_key("val"));
     assert_eq!(errs["val"].len(), 1);
     assert_eq!(errs["val"][0].clone().message.unwrap(), "oops");

--- a/validator_derive/tests/url.rs
+++ b/validator_derive/tests/url.rs
@@ -1,8 +1,10 @@
+#![allow(deprecated)]
+
 #[macro_use]
 extern crate validator_derive;
 extern crate validator;
 
-use validator::{Validate, ValidationErrorsKind};
+use validator::Validate;
 
 
 #[test]
@@ -35,12 +37,8 @@ fn bad_url_fails_validation() {
     assert!(res.is_err());
     let errs = res.unwrap_err().inner();
     assert!(errs.contains_key("val"));
-    if let ValidationErrorsKind::Field(ref err) = errs["val"] {
-        assert_eq!(err.len(), 1);
-        assert_eq!(err[0].code, "url");
-    } else {
-        panic!("Expected field validation errors");
-    }
+    assert_eq!(errs["val"].len(), 1);
+    assert_eq!(errs["val"][0].code, "url");
 }
 
 #[test]
@@ -57,13 +55,9 @@ fn can_specify_code_for_url() {
     assert!(res.is_err());
     let errs = res.unwrap_err().inner();
     assert!(errs.contains_key("val"));
-    if let ValidationErrorsKind::Field(ref err) = errs["val"] {
-        assert_eq!(err.len(), 1);
-        assert_eq!(err[0].code, "oops");
-        assert_eq!(err[0].params["value"], "bob");
-    } else {
-        panic!("Expected field validation errors");
-    }
+    assert_eq!(errs["val"].len(), 1);
+    assert_eq!(errs["val"][0].code, "oops");
+    assert_eq!(errs["val"][0].params["value"], "bob");
 }
 
 #[test]
@@ -80,10 +74,6 @@ fn can_specify_message_for_url() {
     assert!(res.is_err());
     let errs = res.unwrap_err().inner();
     assert!(errs.contains_key("val"));
-    if let ValidationErrorsKind::Field(ref err) = errs["val"] {
-        assert_eq!(err.len(), 1);
-        assert_eq!(err[0].clone().message.unwrap(), "oops");
-    } else {
-        panic!("Expected field validation errors");
-    }
+    assert_eq!(errs["val"].len(), 1);
+    assert_eq!(errs["val"][0].clone().message.unwrap(), "oops");
 }


### PR DESCRIPTION
I've made an implementation of nested struct validation. It uses plain `[#validate]` attributes added to a parent struct's fields in order to detect which nested structs should be validated.
With specialization, it could work without the field attribute as we could speculatively validate all fields, having a default no-op trait implementation for cases where a struct has no real validations to execute. But currently this would have required using nightly so I opted for the explicit attribute approach instead. Also, this gives the user more control over which sub-structs to opt-in for validation.

I aimed to avoid changing the API of the existing library; the main observable difference I think is that the ValidationErrors HashMap is now keyed with a `String` instead of a `&' static str`. I don't know if this will make much difference in real world usage; it didn't cause existing tests to fail at least.
The ValidationErrors keys use a `path.to.nested.field` format to indicate the position of invalid nested fields, and each ValidationError instance includes that path as a `["path", "to", "nested", "field"]` vector for convenience.

This implemetation also works with Optional nested structs and Vectors of nested structs (but currently not combinations of the two).

Keats/validator#31
Keats/validator#51