### PR TITLE
Almost done WIP for adding ability to specify multiple schema-level validation functions.

### DIFF
--- a/validator_derive/src/quoting.rs
+++ b/validator_derive/src/quoting.rs
@@ -430,7 +430,7 @@ pub fn quote_field_validation(
     }
 }
 
-pub fn quote_schema_validation(validation: Option<SchemaValidation>) -> proc_macro2::TokenStream {
+fn quote_single_schema_validation(validation: &Option<SchemaValidation>) -> proc_macro2::TokenStream {
     if let Some(v) = validation {
         let fn_ident = syn::Ident::new(&v.function, Span::call_site());
 
@@ -445,7 +445,7 @@ pub fn quote_schema_validation(validation: Option<SchemaValidation>) -> proc_mac
                 ::std::result::Result::Ok(()) => (),
                 ::std::result::Result::Err(#mut_err_token err) => {
                     #add_message_quoted
-                    errors.add("__all__", err);
+                    schema_errors.add("__all__", err);
                 },
             };
         );
@@ -462,4 +462,8 @@ pub fn quote_schema_validation(validation: Option<SchemaValidation>) -> proc_mac
     } else {
         quote!()
     }
+}
+
+pub fn quote_schema_validation(ref validation: &Vec<Option<SchemaValidation>>) -> Vec<proc_macro2::TokenStream> {
+    validation.iter().map(quote_single_schema_validation).collect::<Vec<_>>()
 }

--- a/validator_derive/tests/schema.rs
+++ b/validator_derive/tests/schema.rs
@@ -22,6 +22,28 @@ fn can_validate_schema_fn_ok() {
 }
 
 #[test]
+fn can_validate_multiple_schema_fn_ok() {
+    fn valid_schema_fn(_: &TestStruct) -> Result<(), ValidationError> {
+        Ok(())
+    }
+
+    fn valid_schema_fn2(_: &TestStruct) -> Result<(), ValidationError> {
+        Ok(())
+    }
+
+    #[derive(Debug, Validate)]
+    #[validate(schema(function = "valid_schema_fn"))]
+    #[validate(schema(function = "valid_schema_fn2"))]
+    struct TestStruct {
+        val: String,
+    }
+
+    let s = TestStruct { val: "hello".to_string() };
+
+    assert!(s.validate().is_ok());
+}
+
+#[test]
 fn can_fail_schema_fn_validation() {
     fn invalid_schema_fn(_: &TestStruct) -> Result<(), ValidationError> {
         Err(ValidationError::new("meh"))
@@ -40,6 +62,33 @@ fn can_fail_schema_fn_validation() {
     assert!(errs.contains_key("__all__"));
     assert_eq!(errs["__all__"].len(), 1);
     assert_eq!(errs["__all__"][0].code, "meh");
+}
+
+#[test]
+fn can_fail_multiple_schema_fn_validation() {
+    fn invalid_schema_fn(_: &TestStruct) -> Result<(), ValidationError> {
+        Err(ValidationError::new("meh"))
+    }
+
+    fn invalid_schema_fn2(_: &TestStruct) -> Result<(), ValidationError> {
+        Err(ValidationError::new("meh2"))
+    }
+
+    #[derive(Debug, Validate)]
+    #[validate(schema(function = "invalid_schema_fn"))]
+    #[validate(schema(function = "invalid_schema_fn2"))]
+    struct TestStruct {
+        val: String,
+    }
+
+    let s = TestStruct { val: String::new() };
+    let res = s.validate();
+    assert!(res.is_err());
+    let errs = res.unwrap_err().field_errors();
+    assert!(errs.contains_key("__all__"));
+    assert_eq!(errs["__all__"].len(), 2);
+    assert_eq!(errs["__all__"][0].code, "meh");
+    assert_eq!(errs["__all__"][1].code, "meh2");
 }
 
 #[test]


### PR DESCRIPTION
As the title says, this PR adds the ability to specify multiple schema level validator functions. This allows for better separation of validation functionality, compared to a series of statements in a single function.

Example (or see the test below)
```
#[derive(Debug, Validate)]
#[validate(schema(function = "schema_fn"))]
#[validate(schema(function = "schema_fn2"))]
struct TestStruct {
    val: String,
}
```

There's one outstanding issue (see the TODO) which I'll look into in the next week or two, but if you have a recommendation on how to solve it please let me know. I'm new to rust and used this as a learning project - was on the look out for a rust equivalent to the pytohn library [schematics](https://github.com/schematics/schematics).

Let me know what you think :)