### PR TITLE
Add utf-8 non-control characters validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,11 @@ Examples:
 #[validate]
 ```
 
+### non_control_character
+Tests whether the String has any utf-8 control caracters, fails validation if it does.
+To use this validator, you must enable the `unic` feature for the `validator_derive` crate.
+This validator doesn't take any arguments: `#[validate(non_control_character)]`;
+
 ## Struct level validation
 Often, some error validation can only be applied when looking at the full struct, here's how it works here:
 

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -19,7 +19,9 @@ serde_derive = "1"
 serde_json = "1"
 card-validate = { version = "2.1", optional = true }
 phonenumber = { version = "0.2.0+8.7.0", optional = true }
+unic-ucd-common = { version = "0.9.0", optional = true }
 
 [features]
 phone = ["phonenumber"]
 card = ["card-validate"]
+unic = ["unic-ucd-common"]

--- a/validator/src/lib.rs
+++ b/validator/src/lib.rs
@@ -23,6 +23,8 @@ pub use validation::email::validate_email;
 pub use validation::ip::{validate_ip, validate_ip_v4, validate_ip_v6};
 pub use validation::length::validate_length;
 pub use validation::must_match::validate_must_match;
+#[cfg(feature = "unic")]
+pub use validation::non_control_character::validate_non_control_character;
 #[cfg(feature = "phone")]
 pub use validation::phone::validate_phone;
 pub use validation::range::validate_range;

--- a/validator/src/validation/email.rs
+++ b/validator/src/validation/email.rs
@@ -120,7 +120,7 @@ mod tests {
         ];
 
         for (input, expected) in tests {
-            println!("{} - {}", input, expected);
+            // println!("{} - {}", input, expected);
             assert_eq!(validate_email(input), expected);
         }
     }

--- a/validator/src/validation/mod.rs
+++ b/validator/src/validation/mod.rs
@@ -5,6 +5,8 @@ pub mod email;
 pub mod ip;
 pub mod length;
 pub mod must_match;
+#[cfg(feature = "unic")]
+pub mod non_control_character;
 #[cfg(feature = "phone")]
 pub mod phone;
 pub mod range;
@@ -41,6 +43,8 @@ pub enum Validator {
     #[cfg(feature = "phone")]
     Phone,
     Nested,
+    #[cfg(feature = "unic")]
+    NonControlCharacter,
 }
 
 impl Validator {
@@ -59,6 +63,8 @@ impl Validator {
             #[cfg(feature = "phone")]
             Validator::Phone => "phone",
             Validator::Nested => "nested",
+            #[cfg(feature = "unic")]
+            Validator::NonControlCharacter => "non_control_character",
         }
     }
 }

--- a/validator/src/validation/non_control_character.rs
+++ b/validator/src/validation/non_control_character.rs
@@ -1,0 +1,46 @@
+use std::borrow::Cow;
+use unic_ucd_common::control;
+
+pub fn validate_non_control_character<'a, T>(alphabetic: T) -> bool
+where
+    T: Into<Cow<'a, str>> + Clone,
+{
+    alphabetic.into().chars().into_iter().all(|code| !control::is_control(code))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::borrow::Cow;
+
+    use super::validate_non_control_character;
+
+    #[test]
+    fn test_non_control_character() {
+        let tests = vec![
+            ("Himmel", true),
+            ("आकाश", true),
+            ("வானத்தில்", true),
+            ("하늘", true),
+            ("небо", true),
+            ("2H₂ + O₂ ⇌ 2H₂O", true),
+            ("\u{000c}", false),
+            ("\u{009F}", false),
+        ];
+
+        for (input, expected) in tests {
+            assert_eq!(validate_non_control_character(input), expected);
+        }
+    }
+
+    #[test]
+    fn test_non_control_character_cow() {
+        let test: Cow<'static, str> = "आकाश".into();
+        assert_eq!(validate_non_control_character(test), true);
+        let test: Cow<'static, str> = String::from("வானத்தில்").into();
+        assert_eq!(validate_non_control_character(test), true);
+        let test: Cow<'static, str> = "\u{000c}".into();
+        assert_eq!(validate_non_control_character(test), false);
+        let test: Cow<'static, str> = String::from("\u{009F}").into();
+        assert_eq!(validate_non_control_character(test), false);
+    }
+}

--- a/validator_derive/Cargo.toml
+++ b/validator_derive/Cargo.toml
@@ -14,6 +14,7 @@ proc-macro = true
 [features]
 phone = ["validator/phone"]
 card = ["validator/card"]
+unic = ["validator/unic"]
 
 [dependencies]
 syn = { version = "0.15", features = ["extra-traits"] }

--- a/validator_derive/src/lib.rs
+++ b/validator_derive/src/lib.rs
@@ -266,7 +266,7 @@ fn find_validators_for_field(
                 for meta_item in meta_items {
                     match *meta_item {
                         syn::NestedMeta::Meta(ref item) => match *item {
-                            // email, url, phone
+                            // email, url, phone, credit_card, non_control_character
                             syn::Meta::Word(ref name) => match name.to_string().as_ref() {
                                 "email" => {
                                     assert_string_type("email", field_type);
@@ -285,6 +285,11 @@ fn find_validators_for_field(
                                 "credit_card" => {
                                     assert_string_type("credit_card", field_type);
                                     validators.push(FieldValidation::new(Validator::CreditCard));
+                                }
+                                #[cfg(feature = "unic")]
+                                "non_control_character" => {
+                                    assert_string_type("non_control_character", field_type);
+                                    validators.push(FieldValidation::new(Validator::NonControlCharacter));
                                 }
                                 _ => panic!("Unexpected validator: {}", name),
                             },
@@ -341,7 +346,7 @@ fn find_validators_for_field(
                                             &meta_items,
                                         ));
                                     }
-                                    "email" | "url" | "phone" | "credit_card" => {
+                                    "email" | "url" | "phone" | "credit_card" | "non_control_character" => {
                                         validators.push(extract_argless_validation(
                                             ident.to_string(),
                                             rust_ident.clone(),

--- a/validator_derive/src/validation.rs
+++ b/validator_derive/src/validation.rs
@@ -146,7 +146,7 @@ pub fn extract_range_validation(
     }
 }
 
-/// Extract url/email/phone field validation with a code or a message
+/// Extract url/email/phone/non_control_character field validation with a code or a message
 pub fn extract_argless_validation(
     validator_name: String,
     field: String,
@@ -178,6 +178,8 @@ pub fn extract_argless_validation(
         "credit_card" => Validator::CreditCard,
         #[cfg(feature = "phone")]
         "phone" => Validator::Phone,
+        #[cfg(feature = "unic")]
+        "non_control_character" => Validator::NonControlCharacter,
         _ => Validator::Url,
     };
 

--- a/validator_derive/tests/non_control.rs
+++ b/validator_derive/tests/non_control.rs
@@ -1,0 +1,75 @@
+#[macro_use]
+extern crate validator_derive;
+extern crate validator;
+
+use validator::Validate;
+
+#[cfg(feature = "unic")]
+#[test]
+fn can_validate_utf8_ok() {
+    #[derive(Debug, Validate)]
+    struct TestStruct {
+        #[validate(non_control_character)]
+        val: String,
+    }
+
+    let s = TestStruct { val: "하늘".to_string() };
+
+    assert!(s.validate().is_ok());
+}
+
+#[cfg(feature = "unic")]
+#[test]
+fn utf8_with_control_fails_validation() {
+    #[derive(Debug, Validate)]
+    struct TestStruct {
+        #[validate(non_control_character)]
+        val: String,
+    }
+
+    let s = TestStruct { val: "\u{009F}하늘".to_string() };
+    let res = s.validate();
+    assert!(res.is_err());
+    let err = res.unwrap_err();
+    let errs = err.field_errors();
+    assert!(errs.contains_key("val"));
+    assert_eq!(errs["val"].len(), 1);
+    assert_eq!(errs["val"][0].code, "non_control_character");
+}
+
+#[cfg(feature = "unic")]
+#[test]
+fn can_specify_code_for_non_control_character() {
+    #[derive(Debug, Validate)]
+    struct TestStruct {
+        #[validate(non_control_character(code = "oops"))]
+        val: String,
+    }
+    let s = TestStruct { val: "\u{009F}하늘".to_string() };
+    let res = s.validate();
+    assert!(res.is_err());
+    let err = res.unwrap_err();
+    let errs = err.field_errors();
+    assert!(errs.contains_key("val"));
+    assert_eq!(errs["val"].len(), 1);
+    assert_eq!(errs["val"][0].code, "oops");
+    assert_eq!(errs["val"][0].params["value"], "\u{9F}하늘");
+}
+
+#[cfg(feature = "unic")]
+#[test]
+fn can_specify_message_for_non_control_character() {
+    #[derive(Debug, Validate)]
+    struct TestStruct {
+        #[validate(non_control_character(message = "oops"))]
+        val: String,
+    }
+    let s = TestStruct { val: "\u{009F}하늘".to_string() };
+    let res = s.validate();
+    assert!(res.is_err());
+    let err = res.unwrap_err();
+    let errs = err.field_errors();
+    assert!(errs.contains_key("val"));
+    assert_eq!(errs["val"].len(), 1);
+    assert_eq!(errs["val"][0].clone().message.unwrap(), "oops");
+}


### PR DESCRIPTION
Rust Strings are utf-8 and it has many control characters, which are sometimes good to test for.
https://bugzilla.mozilla.org/show_bug.cgi?id=968576