### PR TITLE
Add `must_use` attribute to functions returning `bool`

### DIFF
--- a/validator/src/traits.rs
+++ b/validator/src/traits.rs
@@ -49,6 +49,7 @@ impl<'a, T> HasLen for &'a Vec<T> {
 /// Trait to implement if one wants to make the `contains` validator
 /// work for more types
 pub trait Contains {
+    #[must_use]
     fn has_element(&self, needle: &str) -> bool;
 }
 

--- a/validator/src/types.rs
+++ b/validator/src/types.rs
@@ -57,6 +57,7 @@ impl ValidationErrors {
     /// Returns a boolean indicating whether a validation result includes validation errors for a
     /// given field. May be used as a condition for performing nested struct validations on a field
     /// in the absence of field-level validation errors.
+    #[must_use]
     pub fn has_error(result: &Result<(), ValidationErrors>, field: &'static str) -> bool {
         match result {
             Ok(()) => false,
@@ -144,6 +145,7 @@ impl ValidationErrors {
         }
     }
 
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
@@ -156,6 +158,7 @@ impl ValidationErrors {
         }
     }
 
+    #[must_use]
     fn contains_key(&self, field: &'static str) -> bool {
         self.0.contains_key(field)
     }

--- a/validator/src/validation/cards.rs
+++ b/validator/src/validation/cards.rs
@@ -2,6 +2,7 @@ use std::borrow::Cow;
 
 use card_validate::Validate as CardValidate;
 
+#[must_use]
 pub fn validate_credit_card<'a, T>(card: T) -> bool
 where
     T: Into<Cow<'a, str>>,

--- a/validator/src/validation/contains.rs
+++ b/validator/src/validation/contains.rs
@@ -3,6 +3,7 @@ use crate::traits::Contains;
 /// Validates whether the value contains the needle
 /// The value needs to implement the Contains trait, which is implement on String, str and Hashmap<String>
 /// by default.
+#[must_use]
 pub fn validate_contains<T: Contains>(val: T, needle: &str) -> bool {
     val.has_element(needle)
 }

--- a/validator/src/validation/email.rs
+++ b/validator/src/validation/email.rs
@@ -18,6 +18,7 @@ lazy_static! {
 }
 
 /// Validates whether the given string is an email based on Django `EmailValidator` and HTML5 specs
+#[must_use]
 pub fn validate_email<'a, T>(val: T) -> bool
 where
     T: Into<Cow<'a, str>>,
@@ -46,6 +47,7 @@ where
 }
 
 /// Checks if the domain is a valid domain and if not, check whether it's an IP
+#[must_use]
 fn validate_domain_part(domain_part: &str) -> bool {
     if EMAIL_DOMAIN_RE.is_match(domain_part) {
         return true;

--- a/validator/src/validation/ip.rs
+++ b/validator/src/validation/ip.rs
@@ -3,6 +3,7 @@ use std::net::IpAddr;
 use std::str::FromStr;
 
 /// Validates whether the given string is an IP V4
+#[must_use]
 pub fn validate_ip_v4<'a, T>(val: T) -> bool
 where
     T: Into<Cow<'a, str>>,
@@ -17,6 +18,7 @@ where
 }
 
 /// Validates whether the given string is an IP V6
+#[must_use]
 pub fn validate_ip_v6<'a, T>(val: T) -> bool
 where
     T: Into<Cow<'a, str>>,
@@ -31,6 +33,7 @@ where
 }
 
 /// Validates whether the given string is an IP
+#[must_use]
 pub fn validate_ip<'a, T>(val: T) -> bool
 where
     T: Into<Cow<'a, str>>,

--- a/validator/src/validation/length.rs
+++ b/validator/src/validation/length.rs
@@ -6,6 +6,7 @@ use crate::validation::Validator;
 ///
 /// If you apply it on String, don't forget that the length can be different
 /// from the number of visual characters for Unicode
+#[must_use]
 pub fn validate_length<T: HasLen>(length: Validator, val: T) -> bool {
     match length {
         Validator::Length { min, max, equal } => {

--- a/validator/src/validation/must_match.rs
+++ b/validator/src/validation/must_match.rs
@@ -1,5 +1,6 @@
 /// Validates that the 2 given fields match.
 /// Both fields are optionals
+#[must_use]
 pub fn validate_must_match<T: Eq>(a: T, b: T) -> bool {
     a == b
 }

--- a/validator/src/validation/non_control_character.rs
+++ b/validator/src/validation/non_control_character.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 use unic_ucd_common::control;
 
+#[must_use]
 pub fn validate_non_control_character<'a, T>(alphabetic: T) -> bool
 where
     T: Into<Cow<'a, str>> + Clone,

--- a/validator/src/validation/phone.rs
+++ b/validator/src/validation/phone.rs
@@ -1,6 +1,7 @@
 use phonenumber;
 use std::borrow::Cow;
 
+#[must_use]
 pub fn validate_phone<'a, T>(phone_number: T) -> bool
 where
     T: Into<Cow<'a, str>>,

--- a/validator/src/validation/range.rs
+++ b/validator/src/validation/range.rs
@@ -3,6 +3,7 @@ use crate::validation::Validator;
 /// Validates that a number is in the given range
 ///
 /// TODO: see if can be generic over the number type
+#[must_use]
 pub fn validate_range(range: Validator, val: f64) -> bool {
     match range {
         Validator::Range { min, max } => {

--- a/validator/src/validation/urls.rs
+++ b/validator/src/validation/urls.rs
@@ -2,6 +2,7 @@ use std::borrow::Cow;
 use url::Url;
 
 /// Validates whether the string given is a url
+#[must_use]
 pub fn validate_url<'a, T>(val: T) -> bool
 where
     T: Into<Cow<'a, str>>,


### PR DESCRIPTION
This leads to warnings if the return value isn't used. I found this particularly helpful in languages like C++, where returning `bool` is much more prone to human misuse than throwing an exception.