### PR TITLE
Specify static lifetime for field_errors

### DIFF
--- a/validator/src/types.rs
+++ b/validator/src/types.rs
@@ -121,7 +121,7 @@ impl ValidationErrors {
     }
 
     /// Returns a map of only field-level validation errors found for the struct that was validated.
-    pub fn field_errors(&self) -> HashMap<&str, &Vec<ValidationError>> {
+    pub fn field_errors(&self) -> HashMap<&'static str, &Vec<ValidationError>> {
         self.0
             .iter()
             .filter_map(|(k, v)| {


### PR DESCRIPTION
Noticed that this could be a `'static` lifetime when using this library in my webserver.