### PR TITLE
Add a blanket Validate implementation for references

### DIFF
--- a/validator/src/traits.rs
+++ b/validator/src/traits.rs
@@ -93,3 +93,9 @@ impl<'a, S, H: ::std::hash::BuildHasher> Contains for &'a HashMap<String, S, H> 
 pub trait Validate {
     fn validate(&self) -> Result<(), ValidationErrors>;
 }
+
+impl<T: Validate> Validate for &T {
+    fn validate(&self) -> Result<(), ValidationErrors> {
+        T::validate(*self)
+    }
+}

--- a/validator_derive/tests/range.rs
+++ b/validator_derive/tests/range.rs
@@ -2,7 +2,7 @@
 extern crate validator_derive;
 extern crate validator;
 
-use validator::Validate;
+use validator::{Validate, ValidationErrors};
 
 #[test]
 fn can_validate_range_ok() {
@@ -70,4 +70,23 @@ fn can_specify_message_for_range() {
     assert!(errs.contains_key("val"));
     assert_eq!(errs["val"].len(), 1);
     assert_eq!(errs["val"][0].clone().message.unwrap(), "oops");
+}
+
+#[test]
+fn can_pass_reference_as_validate() {
+    // This tests that the blanket Validate implementation on
+    // `&T where T:Validate` works properly
+
+    #[derive(Validate)]
+    struct TestStruct {
+        #[validate(range(min = 100))]
+        num_field: u32,
+    }
+
+    fn validate<T: Validate>(value: T) -> Result<(), ValidationErrors> {
+        value.validate()
+    }
+
+    let val = TestStruct { num_field: 10 };
+    validate(&val).unwrap_err();
 }


### PR DESCRIPTION
As promised, a blanket impl for `Validate` on references to types that are already `Validate`. I confirmed this is working by testing it in my own crate. Closes issue #101 