### PR TITLE
Invalide Emails

### DIFF
--- a/validator/src/validation/email.rs
+++ b/validator/src/validation/email.rs
@@ -9,7 +9,7 @@ lazy_static! {
     // Regex from the specs
     // https://html.spec.whatwg.org/multipage/forms.html#valid-e-mail-address
     // It will mark esoteric email addresses like quoted string as invalid
-    static ref EMAIL_USER_RE: Regex = Regex::new(r"^(?i)[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*\z").unwrap();
+    static ref EMAIL_USER_RE: Regex = Regex::new(r"^(?i)[a-z0-9.!#$%&'*+/=?^_`{|}~-]+\z").unwrap();
     static ref EMAIL_DOMAIN_RE: Regex = Regex::new(
         r"(?i)^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)*$"
     ).unwrap();
@@ -17,10 +17,9 @@ lazy_static! {
     static ref EMAIL_LITERAL_RE: Regex = Regex::new(r"(?i)\[([A-f0-9:\.]+)\]\z").unwrap();
 }
 
-/// Validates whether the given string is an email based on Django `EmailValidator` and HTML5 specs
-///
-/// Quoted email addresses are not accepted as valid (eg. `"John..Doe"@example.com`).
-/// invalid.
+/// Validates whether the given string is an email based on the [HTML5 spec](https://html.spec.whatwg.org/multipage/forms.html#valid-e-mail-address).
+/// [RFC 5322](https://tools.ietf.org/html/rfc5322) is not practical in most circumstances and allows email addresses
+/// that are unfamiliar to most users.
 #[must_use]
 pub fn validate_email<'a, T>(val: T) -> bool
 where
@@ -125,14 +124,6 @@ mod tests {
             ("a@[127.0.0.1]\n", false),
             // underscores are not allowed
             ("John.Doe@exam_ple.com", false),
-            // dots not as first or last char and not followed by dots
-            ("John..Doe@example.com", false),
-            (".John.Doe@example.com", false),
-            ("John.Doe.@example.com", false),
-            // Wikipedia lists them as as valid. https://en.wikipedia.org/wiki/Email_address
-            // (r#""John..Doe"@example.com"#, true),
-            // (r#"".John.Doe"@example.com"#, true),
-            // (r#""John.Doe."@example.com"#, true),
         ];
 
         for (input, expected) in tests {

--- a/validator/src/validation/email.rs
+++ b/validator/src/validation/email.rs
@@ -9,9 +9,9 @@ lazy_static! {
     // Regex from the specs
     // https://html.spec.whatwg.org/multipage/forms.html#valid-e-mail-address
     // It will mark esoteric email addresses like quoted string as invalid
-    static ref EMAIL_USER_RE: Regex = Regex::new(r"^(?i)[a-z0-9.!#$%&'*+/=?^_`{|}~-]+\z").unwrap();
+    static ref EMAIL_USER_RE: Regex = Regex::new(r"^(?i)[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*\z").unwrap();
     static ref EMAIL_DOMAIN_RE: Regex = Regex::new(
-        r"(?i)^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)*$"
+        r"(?i)^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)*$"
     ).unwrap();
     // literal form, ipv4 or ipv6 address (SMTP 4.1.3)
     static ref EMAIL_LITERAL_RE: Regex = Regex::new(r"(?i)\[([A-f0-9:\.]+)\]\z").unwrap();
@@ -92,14 +92,14 @@ mod tests {
                 "a@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.bbbbbbbbbb.atm",
                 true,
             ),
-            ("a@atm.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", true),
+            // 64 * a
+            ("a@atm.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", false),
             ("", false),
             ("abc", false),
             ("abc@", false),
             ("abc@bar", true),
             ("a @x.cz", false),
-            // TODO: make that one below fail
-            // ("abc@.com", false),
+            ("abc@.com", false),
             ("something@@somewhere.com", false),
             ("email@127.0.0.1", true),
             ("email@[127.0.0.256]", false),
@@ -120,11 +120,26 @@ mod tests {
             ("a\n@b.com", false),
             (r#""test@test"\n@example.com"#, false),
             ("a@[127.0.0.1]\n", false),
+            // underscores are not allowed
+            ("John.Doe@exam_ple.com", false),
+            // dots not as first or last char and not followed by dots
+            ("John..Doe@example.com", false),
+            (".John.Doe@example.com", false),
+            ("John.Doe.@example.com", false),
+            // Wikipedia lists them as as valid. https://en.wikipedia.org/wiki/Email_address
+            // (r#""John..Doe"@example.com"#, true),
+            // (r#"".John.Doe"@example.com"#, true),
+            // (r#""John.Doe."@example.com"#, true),
         ];
 
         for (input, expected) in tests {
             // println!("{} - {}", input, expected);
-            assert_eq!(validate_email(input), expected);
+            assert_eq!(
+                validate_email(input),
+                expected,
+                "Email `{}` was not classified correctly",
+                input
+            );
         }
     }
 

--- a/validator/src/validation/email.rs
+++ b/validator/src/validation/email.rs
@@ -18,6 +18,9 @@ lazy_static! {
 }
 
 /// Validates whether the given string is an email based on Django `EmailValidator` and HTML5 specs
+///
+/// Quoted email addresses are not accepted as valid (eg. `"John..Doe"@example.com`).
+/// invalid.
 #[must_use]
 pub fn validate_email<'a, T>(val: T) -> bool
 where


### PR DESCRIPTION
The email validation accepted a few addresses that are invalid (eg. `.John.Doe@example.com`, `John..Doe@example.com`, `John.Doe@exam_ple.com`).

This PR changes the regex so that those addresses are not accepted.

I also think that `a@atm.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa` should be invalid since there are 64 `a`s?