### PR TITLE
Improve proc macro errors

### DIFF
--- a/validator_derive/Cargo.toml
+++ b/validator_derive/Cargo.toml
@@ -21,6 +21,7 @@ unic = ["validator_types/unic"]
 syn = { version = "1", features = ["extra-traits"] }
 quote = "1"
 proc-macro2 = "1"
+proc-macro-error = "1"
 if_chain = "1"
 validator_types = { version = "0.10", path = "../validator_types" }
 regex = "1"

--- a/validator_derive/src/asserts.rs
+++ b/validator_derive/src/asserts.rs
@@ -1,6 +1,8 @@
 use regex::Regex;
 
 use lazy_static::lazy_static;
+use proc_macro_error::abort;
+use syn::spanned::Spanned;
 
 lazy_static! {
     pub static ref COW_TYPE: Regex = Regex::new(r"Cow<'[a-z]+,str>").unwrap();
@@ -45,57 +47,65 @@ pub static NUMBER_TYPES: [&str; 36] = [
     "Option<Option<f64>>",
 ];
 
-pub fn assert_string_type(name: &str, field_type: &str) {
-    if field_type != "String"
-        && field_type != "&str"
-        && !COW_TYPE.is_match(field_type)
-        && field_type != "Option<String>"
-        && field_type != "Option<Option<String>>"
-        && !(field_type.starts_with("Option<") && field_type.ends_with("str>"))
-        && !(field_type.starts_with("Option<Option<") && field_type.ends_with("str>>"))
+pub fn assert_string_type(name: &str, type_name: &str, field_type: &syn::Type) {
+    if type_name != "String"
+        && type_name != "&str"
+        && !COW_TYPE.is_match(type_name)
+        && type_name != "Option<String>"
+        && type_name != "Option<Option<String>>"
+        && !(type_name.starts_with("Option<") && type_name.ends_with("str>"))
+        && !(type_name.starts_with("Option<Option<") && type_name.ends_with("str>>"))
     {
-        panic!(
+        abort!(
+            field_type.span(),
             "`{}` validator can only be used on String, &str, Cow<'_,str> or an Option of those",
             name
         );
     }
 }
 
-pub fn assert_type_matches(field_name: String, field_type: &str, field_type2: Option<&String>) {
+pub fn assert_type_matches(
+    field_name: String,
+    field_type: &str,
+    field_type2: Option<&String>,
+    field_attr: &syn::Attribute,
+) {
     if let Some(t2) = field_type2 {
         if field_type != t2 {
-            panic!("Invalid argument for `must_match` validator of field `{}`: types of field can't match", field_name);
+            abort!(field_attr.span(), "Invalid argument for `must_match` validator of field `{}`: types of field can't match", field_name);
         }
     } else {
-        panic!("Invalid argument for `must_match` validator of field `{}`: the other field doesn't exist in struct", field_name);
+        abort!(field_attr.span(), "Invalid argument for `must_match` validator of field `{}`: the other field doesn't exist in struct", field_name);
     }
 }
 
-pub fn assert_has_len(field_name: String, field_type: &str) {
-    if field_type != "String"
-        && !field_type.starts_with("Vec<")
-        && !field_type.starts_with("Option<Vec<")
-        && !field_type.starts_with("Option<Option<Vec<")
-        && field_type != "Option<String>"
-        && field_type != "Option<Option<String>>"
+pub fn assert_has_len(field_name: String, type_name: &str, field_type: &syn::Type) {
+    if type_name != "String"
+        && !type_name.starts_with("Vec<")
+        && !type_name.starts_with("Option<Vec<")
+        && !type_name.starts_with("Option<Option<Vec<")
+        && type_name != "Option<String>"
+        && type_name != "Option<Option<String>>"
         // a bit ugly
-        && !(field_type.starts_with("Option<") && field_type.ends_with("str>"))
-        && !(field_type.starts_with("Option<Option<") && field_type.ends_with("str>>"))
-        && !COW_TYPE.is_match(field_type)
-        && field_type != "&str"
+        && !(type_name.starts_with("Option<") && type_name.ends_with("str>"))
+        && !(type_name.starts_with("Option<Option<") && type_name.ends_with("str>>"))
+        && !COW_TYPE.is_match(type_name)
+        && type_name != "&str"
     {
-        panic!(
+        abort!(field_type.span(),
                 "Validator `length` can only be used on types `String`, `&str`, Cow<'_,str> or `Vec` but found `{}` for field `{}`",
-                field_type, field_name
+                type_name, field_name
             );
     }
 }
 
-pub fn assert_has_range(field_name: String, field_type: &str) {
-    if !NUMBER_TYPES.contains(&field_type) {
-        panic!(
+pub fn assert_has_range(field_name: String, type_name: &str, field_type: &syn::Type) {
+    if !NUMBER_TYPES.contains(&type_name) {
+        abort!(
+            field_type.span(),
             "Validator `range` can only be used on number types but found `{}` for field `{}`",
-            field_type, field_name
+            type_name,
+            field_name
         );
     }
 }

--- a/validator_derive/src/lib.rs
+++ b/validator_derive/src/lib.rs
@@ -1,9 +1,11 @@
 #![recursion_limit = "128"]
 use if_chain::if_chain;
+use proc_macro2::Span;
+use proc_macro_error::{abort, proc_macro_error};
 use quote::quote;
 use quote::ToTokens;
 use std::collections::HashMap;
-use syn::parse_quote;
+use syn::{parse_quote, spanned::Spanned};
 use validator_types::Validator;
 
 mod asserts;
@@ -17,6 +19,7 @@ use quoting::{quote_field_validation, quote_schema_validation, FieldQuoter};
 use validation::*;
 
 #[proc_macro_derive(Validate, attributes(validate))]
+#[proc_macro_error]
 pub fn derive_validation(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let ast = syn::parse(input).unwrap();
     impl_validate(&ast).into()
@@ -27,11 +30,11 @@ fn impl_validate(ast: &syn::DeriveInput) -> proc_macro2::TokenStream {
     let fields = match ast.data {
         syn::Data::Struct(syn::DataStruct { ref fields, .. }) => {
             if fields.iter().any(|field| field.ident.is_none()) {
-                panic!("struct has unnamed fields");
+                abort!(fields.span(), "struct has unnamed fields");
             }
             fields.iter().cloned().collect::<Vec<_>>()
         }
-        _ => panic!("#[derive(Validate)] can only be used with structs"),
+        _ => abort!(ast.span(), "#[derive(Validate)] can only be used with structs"),
     };
 
     let mut validations = vec![];
@@ -88,8 +91,8 @@ fn impl_validate(ast: &syn::DeriveInput) -> proc_macro2::TokenStream {
 
 /// Find if a struct has some schema validation and returns the info if so
 fn find_struct_validation(struct_attrs: &[syn::Attribute]) -> Option<SchemaValidation> {
-    let error = |msg: &str| -> ! {
-        panic!("Invalid schema level validation: {}", msg);
+    let error = |span: Span, msg: &str| -> ! {
+        abort!(span, "Invalid schema level validation: {}", msg);
     };
 
     for attr in struct_attrs {
@@ -105,7 +108,7 @@ fn find_struct_validation(struct_attrs: &[syn::Attribute]) -> Option<SchemaValid
             then {
                 let ident = path.get_ident().unwrap();
                 if ident != "schema" {
-                    error("Only `schema` is allowed as validator on a struct")
+                    error(attr.span(), "Only `schema` is allowed as validator on a struct")
                 }
 
                 let mut function = String::new();
@@ -124,41 +127,41 @@ fn find_struct_validation(struct_attrs: &[syn::Attribute]) -> Option<SchemaValid
                                 "function" => {
                                     function = match lit_to_string(lit) {
                                         Some(s) => s,
-                                        None => error("invalid argument type for `function` \
+                                        None => error(lit.span(), "invalid argument type for `function` \
                                         : only a string is allowed"),
                                     };
                                 },
                                 "skip_on_field_errors" => {
                                     skip_on_field_errors = match lit_to_bool(lit) {
                                         Some(s) => s,
-                                        None => error("invalid argument type for `skip_on_field_errors` \
+                                        None => error(lit.span(), "invalid argument type for `skip_on_field_errors` \
                                         : only a bool is allowed"),
                                     };
                                 },
                                 "code" => {
                                     code = match lit_to_string(lit) {
                                         Some(s) => Some(s),
-                                        None => error("invalid argument type for `code` \
+                                        None => error(lit.span(), "invalid argument type for `code` \
                                         : only a string is allowed"),
                                     };
                                 },
                                 "message" => {
                                     message = match lit_to_string(lit) {
                                         Some(s) => Some(s),
-                                        None => error("invalid argument type for `message` \
+                                        None => error(lit.span(), "invalid argument type for `message` \
                                         : only a string is allowed"),
                                     };
                                 },
-                                _ => error("Unknown argument")
+                                _ => error(lit.span(), "Unknown argument")
                             }
                         } else {
-                            error("Unexpected args")
+                            error(arg.span(), "Unexpected args")
                         }
                     }
                 }
 
                 if function == "" {
-                    error("`function` is required");
+                    error(path.span(), "`function` is required");
                 }
 
                 return Some(
@@ -170,7 +173,7 @@ fn find_struct_validation(struct_attrs: &[syn::Attribute]) -> Option<SchemaValid
                     }
                 );
             } else {
-                error("Unexpected struct validator")
+                error(attr.span(), "Unexpected struct validator")
             }
         }
     }
@@ -200,7 +203,12 @@ fn find_fields_type(fields: &[syn::Field]) -> HashMap<String, String> {
                 }
                 name
             }
-            _ => panic!("Type `{:?}` of field `{}` not supported", field.ty, field_ident),
+            _ => abort!(
+                field.ty.span(),
+                "Type `{:?}` of field `{}` not supported",
+                field.ty,
+                field_ident
+            ),
         };
 
         //println!("{:?}", field_type);
@@ -219,8 +227,9 @@ fn find_validators_for_field(
     let rust_ident = field.ident.clone().unwrap().to_string();
     let mut field_ident = field.ident.clone().unwrap().to_string();
 
-    let error = |msg: &str| -> ! {
-        panic!(
+    let error = |span: Span, msg: &str| -> ! {
+        abort!(
+            span,
             "Invalid attribute #[validate] on field `{}`: {}",
             field.ident.clone().unwrap().to_string(),
             msg
@@ -260,27 +269,31 @@ fn find_validators_for_field(
                             syn::Meta::Path(ref name) => {
                                 match name.get_ident().unwrap().to_string().as_ref() {
                                     "email" => {
-                                        assert_string_type("email", field_type);
+                                        assert_string_type("email", field_type, &field.ty);
                                         validators.push(FieldValidation::new(Validator::Email));
                                     }
                                     "url" => {
-                                        assert_string_type("url", field_type);
+                                        assert_string_type("url", field_type, &field.ty);
                                         validators.push(FieldValidation::new(Validator::Url));
                                     }
                                     #[cfg(feature = "phone")]
                                     "phone" => {
-                                        assert_string_type("phone", field_type);
+                                        assert_string_type("phone", field_type, &field.ty);
                                         validators.push(FieldValidation::new(Validator::Phone));
                                     }
                                     #[cfg(feature = "card")]
                                     "credit_card" => {
-                                        assert_string_type("credit_card", field_type);
+                                        assert_string_type("credit_card", field_type, &field.ty);
                                         validators
                                             .push(FieldValidation::new(Validator::CreditCard));
                                     }
                                     #[cfg(feature = "unic")]
                                     "non_control_character" => {
-                                        assert_string_type("non_control_character", field_type);
+                                        assert_string_type(
+                                            "non_control_character",
+                                            field_type,
+                                            &field.ty,
+                                        );
                                         validators.push(FieldValidation::new(
                                             Validator::NonControlCharacter,
                                         ));
@@ -292,7 +305,11 @@ fn find_validators_for_field(
                                         validators.push(FieldValidation::new(Validator::Required));
                                         validators.push(FieldValidation::new(Validator::Nested));
                                     }
-                                    _ => panic!("Unexpected validator: {:?}", name.get_ident()),
+                                    _ => abort!(
+                                        name.span(),
+                                        "Unexpected validator: {:?}",
+                                        name.get_ident()
+                                    ),
                                 }
                             }
                             // custom, contains, must_match, regex
@@ -304,31 +321,35 @@ fn find_validators_for_field(
                                     "custom" => {
                                         match lit_to_string(lit) {
                                             Some(s) => validators.push(FieldValidation::new(Validator::Custom(s))),
-                                            None => error("invalid argument for `custom` validator: only strings are allowed"),
+                                            None => error(lit.span(), "invalid argument for `custom` validator: only strings are allowed"),
                                         };
                                     }
                                     "contains" => {
                                         match lit_to_string(lit) {
                                             Some(s) => validators.push(FieldValidation::new(Validator::Contains(s))),
-                                            None => error("invalid argument for `contains` validator: only strings are allowed"),
+                                            None => error(lit.span(), "invalid argument for `contains` validator: only strings are allowed"),
                                         };
                                     }
                                     "regex" => {
                                         match lit_to_string(lit) {
                                             Some(s) => validators.push(FieldValidation::new(Validator::Regex(s))),
-                                            None => error("invalid argument for `regex` validator: only strings are allowed"),
+                                            None => error(lit.span(), "invalid argument for `regex` validator: only strings are allowed"),
                                         };
                                     }
                                     "must_match" => {
                                         match lit_to_string(lit) {
                                             Some(s) => {
-                                                assert_type_matches(rust_ident.clone(), field_type, field_types.get(&s));
+                                                assert_type_matches(rust_ident.clone(), field_type, field_types.get(&s), &attr);
                                                 validators.push(FieldValidation::new(Validator::MustMatch(s)));
                                             },
-                                            None => error("invalid argument for `must_match` validator: only strings are allowed"),
+                                            None => error(lit.span(), "invalid argument for `must_match` validator: only strings are allowed"),
                                         };
                                     }
-                                    v => panic!("unexpected name value validator: {:?}", v),
+                                    v => abort!(
+                                        item.span(),
+                                        "unexpected name value validator: {:?}",
+                                        v
+                                    ),
                                 };
                             }
                             // Validators with several args
@@ -337,16 +358,18 @@ fn find_validators_for_field(
                                 let ident = path.get_ident().unwrap();
                                 match ident.to_string().as_ref() {
                                     "length" => {
-                                        assert_has_len(rust_ident.clone(), field_type);
+                                        assert_has_len(rust_ident.clone(), field_type, &field.ty);
                                         validators.push(extract_length_validation(
                                             rust_ident.clone(),
+                                            attr,
                                             &meta_items,
                                         ));
                                     }
                                     "range" => {
-                                        assert_has_range(rust_ident.clone(), field_type);
+                                        assert_has_range(rust_ident.clone(), field_type, &field.ty);
                                         validators.push(extract_range_validation(
                                             rust_ident.clone(),
+                                            attr,
                                             &meta_items,
                                         ));
                                     }
@@ -397,11 +420,12 @@ fn find_validators_for_field(
                                                 rust_ident.clone(),
                                                 field_type,
                                                 field_types.get(t2),
+                                                &attr,
                                             );
                                         }
                                         validators.push(validation);
                                     }
-                                    v => panic!("unexpected list validator: {:?}", v),
+                                    v => abort!(item.span(), "unexpected list validator: {:?}", v),
                                 }
                             }
                         },
@@ -410,16 +434,16 @@ fn find_validators_for_field(
                 }
             }
             Ok(syn::Meta::Path(_)) => validators.push(FieldValidation::new(Validator::Nested)),
-            Ok(syn::Meta::NameValue(_)) => panic!("Unexpected name=value argument"),
+            Ok(syn::Meta::NameValue(_)) => abort!(attr.span(), "Unexpected name=value argument"),
             Err(e) => unreachable!(
                 "Got something other than a list of attributes while checking field `{}`: {:?}",
                 field_ident, e
             ),
         }
-    }
 
-    if has_validate && validators.is_empty() {
-        error("it needs at least one validator");
+        if has_validate && validators.is_empty() {
+            error(attr.span(), "it needs at least one validator");
+        }
     }
 
     (field_ident, validators)

--- a/validator_derive/tests/compile-fail/custom_not_string.rs
+++ b/validator_derive/tests/compile-fail/custom_not_string.rs
@@ -1,8 +1,6 @@
 use validator::Validate;
 
 #[derive(Validate)]
-//~^ ERROR: proc-macro derive panicked
-//~^^ HELP: Invalid attribute #[validate] on field `s`: invalid argument for `custom` validator: only strings are allowed
 struct Test {
     #[validate(custom = 2)]
     s: String,

--- a/validator_derive/tests/compile-fail/custom_not_string.stderr
+++ b/validator_derive/tests/compile-fail/custom_not_string.stderr
@@ -1,7 +1,5 @@
-error: proc-macro derive panicked
- --> $DIR/custom_not_string.rs:3:10
+error: Invalid attribute #[validate] on field `s`: invalid argument for `custom` validator: only strings are allowed
+ --> $DIR/custom_not_string.rs:5:25
   |
-3 | #[derive(Validate)]
-  |          ^^^^^^^^
-  |
-  = help: message: Invalid attribute #[validate] on field `s`: invalid argument for `custom` validator: only strings are allowed
+5 |     #[validate(custom = 2)]
+  |                         ^

--- a/validator_derive/tests/compile-fail/length/equal_and_min_max_set.rs
+++ b/validator_derive/tests/compile-fail/length/equal_and_min_max_set.rs
@@ -1,8 +1,6 @@
 use validator::Validate;
 
 #[derive(Validate)]
-//~^ ERROR: proc-macro derive panicked
-//~^^ HELP: Invalid attribute #[validate] on field `s`: both `equal` and `min` or `max` have been set in `length` validator: probably a mistake
 struct Test {
     #[validate(length(min = 1, equal = 2))]
     s: String,

--- a/validator_derive/tests/compile-fail/length/equal_and_min_max_set.stderr
+++ b/validator_derive/tests/compile-fail/length/equal_and_min_max_set.stderr
@@ -1,7 +1,5 @@
-error: proc-macro derive panicked
- --> $DIR/equal_and_min_max_set.rs:3:10
+error: Invalid attribute #[validate] on field `s`: both `equal` and `min` or `max` have been set in `length` validator: probably a mistake
+ --> $DIR/equal_and_min_max_set.rs:5:32
   |
-3 | #[derive(Validate)]
-  |          ^^^^^^^^
-  |
-  = help: message: Invalid attribute #[validate] on field `s`: both `equal` and `min` or `max` have been set in `length` validator: probably a mistake
+5 |     #[validate(length(min = 1, equal = 2))]
+  |                                ^^^^^^^^^

--- a/validator_derive/tests/compile-fail/length/no_args.rs
+++ b/validator_derive/tests/compile-fail/length/no_args.rs
@@ -1,8 +1,6 @@
 use validator::Validate;
 
 #[derive(Validate)]
-//~^ ERROR: proc-macro derive panicked
-//~^^ HELP: Invalid attribute #[validate] on field `s`: Validator `length` requires at least 1 argument out of `min`, `max` and `equal`
 struct Test {
     #[validate(length())]
     s: String,

--- a/validator_derive/tests/compile-fail/length/no_args.stderr
+++ b/validator_derive/tests/compile-fail/length/no_args.stderr
@@ -1,7 +1,5 @@
-error: proc-macro derive panicked
- --> $DIR/no_args.rs:3:10
+error: Invalid attribute #[validate] on field `s`: Validator `length` requires at least 1 argument out of `min`, `max` and `equal`
+ --> $DIR/no_args.rs:5:5
   |
-3 | #[derive(Validate)]
-  |          ^^^^^^^^
-  |
-  = help: message: Invalid attribute #[validate] on field `s`: Validator `length` requires at least 1 argument out of `min`, `max` and `equal`
+5 |     #[validate(length())]
+  |     ^^^^^^^^^^^^^^^^^^^^^

--- a/validator_derive/tests/compile-fail/length/unknown_arg.rs
+++ b/validator_derive/tests/compile-fail/length/unknown_arg.rs
@@ -1,8 +1,6 @@
 use validator::Validate;
 
 #[derive(Validate)]
-//~^ ERROR: proc-macro derive panicked
-//~^^ HELP: Invalid attribute #[validate] on field `s`: unknown argument `eq` for validator `length` (it only has `min`, `max`, `equal`)
 struct Test {
     #[validate(length(eq = 2))]
     s: String,

--- a/validator_derive/tests/compile-fail/length/unknown_arg.stderr
+++ b/validator_derive/tests/compile-fail/length/unknown_arg.stderr
@@ -1,7 +1,5 @@
-error: proc-macro derive panicked
- --> $DIR/unknown_arg.rs:3:10
+error: Invalid attribute #[validate] on field `s`: unknown argument `eq` for validator `length` (it only has `min`, `max`, `equal`)
+ --> $DIR/unknown_arg.rs:5:23
   |
-3 | #[derive(Validate)]
-  |          ^^^^^^^^
-  |
-  = help: message: Invalid attribute #[validate] on field `s`: unknown argument `eq` for validator `length` (it only has `min`, `max`, `equal`)
+5 |     #[validate(length(eq = 2))]
+  |                       ^^

--- a/validator_derive/tests/compile-fail/length/wrong_type.rs
+++ b/validator_derive/tests/compile-fail/length/wrong_type.rs
@@ -1,8 +1,6 @@
 use validator::Validate;
 
 #[derive(Validate)]
-//~^ ERROR: proc-macro derive panicked
-//~^^ HELP: Validator `length` can only be used on types `String`, `&str`, Cow<'_,str> or `Vec` but found `usize`
 struct Test {
     #[validate(length())]
     s: usize,

--- a/validator_derive/tests/compile-fail/length/wrong_type.stderr
+++ b/validator_derive/tests/compile-fail/length/wrong_type.stderr
@@ -1,7 +1,5 @@
-error: proc-macro derive panicked
- --> $DIR/wrong_type.rs:3:10
+error: Validator `length` can only be used on types `String`, `&str`, Cow<'_,str> or `Vec` but found `usize` for field `s`
+ --> $DIR/wrong_type.rs:6:8
   |
-3 | #[derive(Validate)]
-  |          ^^^^^^^^
-  |
-  = help: message: Validator `length` can only be used on types `String`, `&str`, Cow<'_,str> or `Vec` but found `usize` for field `s`
+6 |     s: usize,
+  |        ^^^^^

--- a/validator_derive/tests/compile-fail/must_match/field_doesnt_exist.rs
+++ b/validator_derive/tests/compile-fail/must_match/field_doesnt_exist.rs
@@ -1,8 +1,6 @@
 use validator::Validate;
 
 #[derive(Validate)]
-//~^ ERROR: proc-macro derive panicked
-//~^^ HELP: Invalid argument for `must_match` validator of field `password`: the other field doesn't exist in struct
 struct Test {
     #[validate(must_match = "password2")]
     password: String,

--- a/validator_derive/tests/compile-fail/must_match/field_doesnt_exist.stderr
+++ b/validator_derive/tests/compile-fail/must_match/field_doesnt_exist.stderr
@@ -1,7 +1,5 @@
-error: proc-macro derive panicked
- --> $DIR/field_doesnt_exist.rs:3:10
+error: Invalid argument for `must_match` validator of field `password`: the other field doesn't exist in struct
+ --> $DIR/field_doesnt_exist.rs:5:5
   |
-3 | #[derive(Validate)]
-  |          ^^^^^^^^
-  |
-  = help: message: Invalid argument for `must_match` validator of field `password`: the other field doesn't exist in struct
+5 |     #[validate(must_match = "password2")]
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/validator_derive/tests/compile-fail/must_match/field_type_doesnt_match.rs
+++ b/validator_derive/tests/compile-fail/must_match/field_type_doesnt_match.rs
@@ -1,8 +1,6 @@
 use validator::Validate;
 
 #[derive(Validate)]
-//~^ ERROR: proc-macro derive panicked
-//~^^ HELP: Invalid argument for `must_match` validator of field `password`: types of field can't match
 struct Test {
     #[validate(must_match = "password2")]
     password: String,

--- a/validator_derive/tests/compile-fail/must_match/field_type_doesnt_match.stderr
+++ b/validator_derive/tests/compile-fail/must_match/field_type_doesnt_match.stderr
@@ -1,7 +1,5 @@
-error: proc-macro derive panicked
- --> $DIR/field_type_doesnt_match.rs:3:10
+error: Invalid argument for `must_match` validator of field `password`: types of field can't match
+ --> $DIR/field_type_doesnt_match.rs:5:5
   |
-3 | #[derive(Validate)]
-  |          ^^^^^^^^
-  |
-  = help: message: Invalid argument for `must_match` validator of field `password`: types of field can't match
+5 |     #[validate(must_match = "password2")]
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/validator_derive/tests/compile-fail/must_match/unexpected_name_value.rs
+++ b/validator_derive/tests/compile-fail/must_match/unexpected_name_value.rs
@@ -1,0 +1,9 @@
+use validator::Validate;
+
+#[derive(Validate)]
+struct Email {
+    #[validate(not_a = "validator")]
+    email: String,
+}
+
+fn main() {}

--- a/validator_derive/tests/compile-fail/must_match/unexpected_name_value.stderr
+++ b/validator_derive/tests/compile-fail/must_match/unexpected_name_value.stderr
@@ -1,0 +1,5 @@
+error: unexpected name value validator: "not_a"
+ --> $DIR/unexpected_name_value.rs:5:16
+  |
+5 |     #[validate(not_a = "validator")]
+  |                ^^^^^

--- a/validator_derive/tests/compile-fail/no_nested_validations.rs
+++ b/validator_derive/tests/compile-fail/no_nested_validations.rs
@@ -1,8 +1,6 @@
 use validator::Validate;
 
 #[derive(Validate)]
-//~^ ERROR: no method named `validate` found for struct `Nested` in the current scope [E0599]
-//~^^ HELP: items from traits can only be used if the trait is implemented and in scope
 struct Test {
     #[validate]
     nested: Nested,

--- a/validator_derive/tests/compile-fail/no_nested_validations.stderr
+++ b/validator_derive/tests/compile-fail/no_nested_validations.stderr
@@ -9,5 +9,5 @@ error[E0599]: no method named `validate` found for struct `Nested` in the curren
   |
   = help: items from traits can only be used if the trait is implemented and in scope
   = note: the following trait defines an item `validate`, perhaps you need to implement it:
-          candidate #1: `validator::Validate`
+          candidate #1: `Validate`
   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/validator_derive/tests/compile-fail/no_nested_validations.stderr
+++ b/validator_derive/tests/compile-fail/no_nested_validations.stderr
@@ -1,13 +1,13 @@
 error[E0599]: no method named `validate` found for struct `Nested` in the current scope
-  --> $DIR/no_nested_validations.rs:3:10
-   |
-3  | #[derive(Validate)]
-   |          ^^^^^^^^ method not found in `Nested`
+ --> $DIR/no_nested_validations.rs:3:10
+  |
+3 | #[derive(Validate)]
+  |          ^^^^^^^^ method not found in `Nested`
 ...
-11 | struct Nested {
-   | ------------- method `validate` not found for this
-   |
-   = help: items from traits can only be used if the trait is implemented and in scope
-   = note: the following trait defines an item `validate`, perhaps you need to implement it:
-           candidate #1: `validator::Validate`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+9 | struct Nested {
+  | ------------- method `validate` not found for this
+  |
+  = help: items from traits can only be used if the trait is implemented and in scope
+  = note: the following trait defines an item `validate`, perhaps you need to implement it:
+          candidate #1: `validator::Validate`
+  = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/validator_derive/tests/compile-fail/no_validations.rs
+++ b/validator_derive/tests/compile-fail/no_validations.rs
@@ -1,8 +1,6 @@
 use validator::Validate;
 
 #[derive(Validate)]
-//~^ ERROR: proc-macro derive panicked
-//~^^ HELP: Invalid attribute #[validate] on field `s`: it needs at least one validator
 struct Test {
     #[validate()]
     s: String,

--- a/validator_derive/tests/compile-fail/no_validations.stderr
+++ b/validator_derive/tests/compile-fail/no_validations.stderr
@@ -1,7 +1,5 @@
-error: proc-macro derive panicked
- --> $DIR/no_validations.rs:3:10
+error: Invalid attribute #[validate] on field `s`: it needs at least one validator
+ --> $DIR/no_validations.rs:5:5
   |
-3 | #[derive(Validate)]
-  |          ^^^^^^^^
-  |
-  = help: message: Invalid attribute #[validate] on field `s`: it needs at least one validator
+5 |     #[validate()]
+  |     ^^^^^^^^^^^^^

--- a/validator_derive/tests/compile-fail/not_a_string_type.rs
+++ b/validator_derive/tests/compile-fail/not_a_string_type.rs
@@ -1,0 +1,9 @@
+use validator::Validate;
+
+#[derive(Validate)]
+struct Register {
+    #[validate(email)]
+    email: Vec<u8>,
+}
+
+fn main() {}

--- a/validator_derive/tests/compile-fail/not_a_string_type.stderr
+++ b/validator_derive/tests/compile-fail/not_a_string_type.stderr
@@ -1,0 +1,5 @@
+error: `email` validator can only be used on String, &str, Cow<'_,str> or an Option of those
+ --> $DIR/not_a_string_type.rs:6:12
+  |
+6 |     email: Vec<u8>,
+  |            ^^^^^^^

--- a/validator_derive/tests/compile-fail/not_a_struct.rs
+++ b/validator_derive/tests/compile-fail/not_a_struct.rs
@@ -1,0 +1,10 @@
+use validator::Validate;
+
+#[derive(Validate)]
+pub enum NotAStruct {
+    VariantA(i32),
+    VariantB(String),
+    VariantC(Vec<String>),
+}
+
+fn main() {}

--- a/validator_derive/tests/compile-fail/not_a_struct.stderr
+++ b/validator_derive/tests/compile-fail/not_a_struct.stderr
@@ -1,0 +1,9 @@
+error: #[derive(Validate)] can only be used with structs
+ --> $DIR/not_a_struct.rs:4:1
+  |
+4 | / pub enum NotAStruct {
+5 | |     VariantA(i32),
+6 | |     VariantB(String),
+7 | |     VariantC(Vec<String>),
+8 | | }
+  | |_^

--- a/validator_derive/tests/compile-fail/range/no_args.rs
+++ b/validator_derive/tests/compile-fail/range/no_args.rs
@@ -1,8 +1,6 @@
 use validator::Validate;
 
 #[derive(Validate)]
-//~^ ERROR: proc-macro derive panicked
-//~^^ HELP: Invalid attribute #[validate] on field `s`: Validator `range` requires at least 1 argument out of `min` and `max`
 struct Test {
     #[validate(range())]
     s: i32,

--- a/validator_derive/tests/compile-fail/range/no_args.stderr
+++ b/validator_derive/tests/compile-fail/range/no_args.stderr
@@ -1,7 +1,5 @@
-error: proc-macro derive panicked
- --> $DIR/no_args.rs:3:10
+error: Invalid attribute #[validate] on field `s`: Validator `range` requires at least 1 argument out of `min` and `max`
+ --> $DIR/no_args.rs:5:5
   |
-3 | #[derive(Validate)]
-  |          ^^^^^^^^
-  |
-  = help: message: Invalid attribute #[validate] on field `s`: Validator `range` requires at least 1 argument out of `min` and `max`
+5 |     #[validate(range())]
+  |     ^^^^^^^^^^^^^^^^^^^^

--- a/validator_derive/tests/compile-fail/range/unknown_arg.rs
+++ b/validator_derive/tests/compile-fail/range/unknown_arg.rs
@@ -1,8 +1,6 @@
 use validator::Validate;
 
 #[derive(Validate)]
-//~^ ERROR: proc-macro derive panicked
-//~^^ HELP: Invalid attribute #[validate] on field `s`: unknown argument `mi` for validator `range` (it only has `min`, `max`)
 struct Test {
     #[validate(range(mi = 2, max = 3))]
     s: i32,

--- a/validator_derive/tests/compile-fail/range/unknown_arg.stderr
+++ b/validator_derive/tests/compile-fail/range/unknown_arg.stderr
@@ -1,7 +1,5 @@
-error: proc-macro derive panicked
- --> $DIR/unknown_arg.rs:3:10
+error: Invalid attribute #[validate] on field `s`: unknown argument `mi` for validator `range` (it only has `min`, `max`)
+ --> $DIR/unknown_arg.rs:5:22
   |
-3 | #[derive(Validate)]
-  |          ^^^^^^^^
-  |
-  = help: message: Invalid attribute #[validate] on field `s`: unknown argument `mi` for validator `range` (it only has `min`, `max`)
+5 |     #[validate(range(mi = 2, max = 3))]
+  |                      ^^

--- a/validator_derive/tests/compile-fail/range/wrong_type.rs
+++ b/validator_derive/tests/compile-fail/range/wrong_type.rs
@@ -1,8 +1,6 @@
 use validator::Validate;
 
 #[derive(Validate)]
-//~^ ERROR: proc-macro derive panicked
-//~^^ HELP: Validator `range` can only be used on number types but found `String`
 struct Test {
     #[validate(range(min = 10.0, max = 12.0))]
     s: String,

--- a/validator_derive/tests/compile-fail/range/wrong_type.stderr
+++ b/validator_derive/tests/compile-fail/range/wrong_type.stderr
@@ -1,7 +1,5 @@
-error: proc-macro derive panicked
- --> $DIR/wrong_type.rs:3:10
+error: Validator `range` can only be used on number types but found `String` for field `s`
+ --> $DIR/wrong_type.rs:6:8
   |
-3 | #[derive(Validate)]
-  |          ^^^^^^^^
-  |
-  = help: message: Validator `range` can only be used on number types but found `String` for field `s`
+6 |     s: String,
+  |        ^^^^^^

--- a/validator_derive/tests/compile-fail/schema/missing_function.rs
+++ b/validator_derive/tests/compile-fail/schema/missing_function.rs
@@ -1,8 +1,6 @@
 use validator::Validate;
 
 #[derive(Validate)]
-//~^ ERROR: proc-macro derive panicked
-//~^^ HELP: Invalid schema level validation: `function` is required
 #[validate(schema())]
 struct Test {
     s: i32,

--- a/validator_derive/tests/compile-fail/schema/missing_function.stderr
+++ b/validator_derive/tests/compile-fail/schema/missing_function.stderr
@@ -1,7 +1,5 @@
-error: proc-macro derive panicked
- --> $DIR/missing_function.rs:3:10
+error: Invalid schema level validation: `function` is required
+ --> $DIR/missing_function.rs:4:12
   |
-3 | #[derive(Validate)]
-  |          ^^^^^^^^
-  |
-  = help: message: Invalid schema level validation: `function` is required
+4 | #[validate(schema())]
+  |            ^^^^^^

--- a/validator_derive/tests/compile-fail/unexpected_list_validator.rs
+++ b/validator_derive/tests/compile-fail/unexpected_list_validator.rs
@@ -1,0 +1,9 @@
+use validator::Validate;
+
+#[derive(Validate)]
+struct PII {
+    #[validate(not_a_list(a, b, c))]
+    email: String,
+}
+
+fn main() {}

--- a/validator_derive/tests/compile-fail/unexpected_list_validator.stderr
+++ b/validator_derive/tests/compile-fail/unexpected_list_validator.stderr
@@ -1,0 +1,5 @@
+error: unexpected list validator: "not_a_list"
+ --> $DIR/unexpected_list_validator.rs:5:16
+  |
+5 |     #[validate(not_a_list(a, b, c))]
+  |                ^^^^^^^^^^

--- a/validator_derive/tests/compile-fail/unexpected_validator.rs
+++ b/validator_derive/tests/compile-fail/unexpected_validator.rs
@@ -1,0 +1,9 @@
+use validator::Validate;
+
+#[derive(Validate)]
+struct NotAValidator {
+    #[validate(my_custom_validator)]
+    field: String,
+}
+
+fn main() {}

--- a/validator_derive/tests/compile-fail/unexpected_validator.stderr
+++ b/validator_derive/tests/compile-fail/unexpected_validator.stderr
@@ -1,0 +1,5 @@
+error: Unexpected validator: my_custom_validator
+ --> $DIR/unexpected_validator.rs:5:16
+  |
+5 |     #[validate(my_custom_validator)]
+  |                ^^^^^^^^^^^^^^^^^^^

--- a/validator_derive/tests/compile-fail/unnamed_fields.rs
+++ b/validator_derive/tests/compile-fail/unnamed_fields.rs
@@ -1,0 +1,6 @@
+use validator::Validate;
+
+#[derive(Validate)]
+struct TupleStruct(String);
+
+fn main() {}

--- a/validator_derive/tests/compile-fail/unnamed_fields.stderr
+++ b/validator_derive/tests/compile-fail/unnamed_fields.stderr
@@ -1,0 +1,7 @@
+error: struct has unnamed fields
+ --> $DIR/unnamed_fields.rs:4:19
+  |
+4 | struct TupleStruct(String);
+  |                   ^^^^^^^^
+  |
+  = help: #[derive(Validate)] can only be used on structs with named fields

--- a/validator_derive/tests/compile-fail/unsupported_field_type.rs
+++ b/validator_derive/tests/compile-fail/unsupported_field_type.rs
@@ -1,0 +1,8 @@
+use validator::Validate;
+
+#[derive(Validate)]
+struct Values {
+    values: [u8; 10],
+}
+
+fn main() {}

--- a/validator_derive/tests/compile-fail/unsupported_field_type.stderr
+++ b/validator_derive/tests/compile-fail/unsupported_field_type.stderr
@@ -1,0 +1,5 @@
+error: Type `[u8 ; 10]` of field `values` not supported
+ --> $DIR/unsupported_field_type.rs:5:13
+  |
+5 |     values: [u8; 10],
+  |             ^^^^^^^^

--- a/validator_derive/tests/range.rs
+++ b/validator_derive/tests/range.rs
@@ -1,5 +1,12 @@
 use validator::{Validate, ValidationErrors};
 
+// Loose floating point comparison using EPSILON error bound
+macro_rules! assert_float {
+    ($e1:expr, $e2:expr) => {
+        assert!(($e2 - $e1).abs() < f64::EPSILON);
+    };
+}
+
 #[test]
 fn can_validate_range_ok() {
     #[derive(Debug, Validate)]
@@ -47,8 +54,8 @@ fn can_specify_code_for_range() {
     assert_eq!(errs["val"].len(), 1);
     assert_eq!(errs["val"][0].code, "oops");
     assert_eq!(errs["val"][0].params["value"], 11);
-    assert_eq!(errs["val"][0].params["min"], 5.0);
-    assert_eq!(errs["val"][0].params["max"], 10.0);
+    assert_float!(errs["val"][0].params["min"].as_f64().unwrap(), 5.0);
+    assert_float!(errs["val"][0].params["max"].as_f64().unwrap(), 10.0);
 }
 
 #[test]


### PR DESCRIPTION
Not meaning to spam with PRs, but I figured it would be nice to improve the procedural macro errors by using the `compile_error!` macro instead of `panic!`, since an error in the procedural macro, semantically, _is a_ compiler error and not a runtime panic.

I found the `proc-macro-error` library that acts as a shim between the `compile_error!` macro on stable and the Diagnostics API on nightly that works well and required minimal changes to the `panic!` messages. This is a starting point that can be built upon to improve the error messages presented to the user.

An example of the error message changes:

Current:
```
error: proc-macro derive panicked
 --> $DIR/custom_not_string.rs:3:10
  |
3 | #[derive(Validate)]
  |          ^^^^^^^^
  |
  = help: message: Invalid attribute #[validate] on field `s`: invalid argument for `custom` validator: only strings are allowed
```

New
```
error: Invalid attribute #[validate] on field `s`: invalid argument for `custom` validator: only strings are allowed
 --> $DIR/custom_not_string.rs:5:25
  |
5 |     #[validate(custom = 2)]
  |                         ^
```

This branch is based on #109.