### PR TITLE
Use absolute path for trait impl

### DIFF
--- a/validator_derive/src/lib.rs
+++ b/validator_derive/src/lib.rs
@@ -69,7 +69,7 @@ fn impl_validate(ast: &syn::DeriveInput) -> proc_macro2::TokenStream {
     // Helper is provided for handling complex generic types correctly and effortlessly
     let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
     let impl_ast = quote!(
-        impl #impl_generics Validate for #ident #ty_generics #where_clause {
+        impl #impl_generics ::validator::Validate for #ident #ty_generics #where_clause {
             #[allow(unused_mut)]
             fn validate(&self) -> ::std::result::Result<(), ::validator::ValidationErrors> {
                 let mut errors = ::validator::ValidationErrors::new();

--- a/validator_derive/tests/run-pass/absolute_path.rs
+++ b/validator_derive/tests/run-pass/absolute_path.rs
@@ -1,0 +1,15 @@
+#[derive(
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    ::serde::Serialize,
+    ::serde::Deserialize,
+    ::validator_derive::Validate,
+)]
+pub struct Message {
+    #[validate(length(min = 1i64, max = 2048i64))]
+    pub text: String,
+}
+
+fn main() {}


### PR DESCRIPTION
Turns out this one was pretty trivial. Just a one-line change in the code generated by the procedural macro! 🎉 

Resolves #112