### PR TITLE
README.md: Use Rust 2018 edition, Validate derive reexport

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,7 @@ validator = { version = "0.11", features = ["derive"] }
 A short example:
 
 ```rust
-#[macro_use]
-extern crate validator_derive;
-extern crate validator;
-#[macro_use]
-extern crate serde_derive;
-extern crate serde_json;
-
+use serde::Deserialize;
 // A trait that the Validate derive will impl
 use validator::{Validate, ValidationError};
 
@@ -96,12 +90,9 @@ The other two `ValidationErrorsKind` types represent errors discovered in nested
 this example:
 
  ```rust
-#[macro_use]
-extern crate validator_derive;
-extern crate validator;
-#[macro_use]
-extern crate serde_derive;
-extern crate serde_json;
+use serde::Deserialize;
+// A trait that the Validate derive will impl
+use validator::Validate;
 
 #[derive(Debug, Validate, Deserialize)]
 struct SignupData {


### PR DESCRIPTION
- there is no need for `#[macro_use]`, `extern_crate`
- make use of the fact that `Validate` *attribute macro* is now reexported at the same path as the trait, `validator::Validate`
- `serde_json` was not used in examples, no need to mention it

Note: I haven't actually tried to compile it, but hopefully that's "obvious enough"? :)