### PR TITLE
asserts: Add support for references to length types

### DIFF
--- a/validator_derive/src/asserts.rs
+++ b/validator_derive/src/asserts.rs
@@ -80,6 +80,15 @@ pub fn assert_type_matches(
 }
 
 pub fn assert_has_len(field_name: String, type_name: &str, field_type: &syn::Type) {
+    if let syn::Type::Reference(ref tref) = field_type {
+        let elem = &tref.elem;
+        let type_name = format!("{}", quote::quote!{ #elem }).replace(' ', "");
+
+        if type_name == "str" { return }
+        assert_has_len(field_name, &type_name, elem);
+        return;
+    }
+
     if type_name != "String"
         && !type_name.starts_with("Vec<")
         && !type_name.starts_with("Option<Vec<")

--- a/validator_derive/tests/length.rs
+++ b/validator_derive/tests/length.rs
@@ -67,3 +67,27 @@ fn can_specify_message_for_length() {
     assert_eq!(errs["val"].len(), 1);
     assert_eq!(errs["val"][0].clone().message.unwrap(), "oops");
 }
+
+#[test]
+fn can_validate_ref_for_length() {
+    use serde_json::Value;
+
+    #[derive(Debug, Validate)]
+    struct TestStruct<'a> {
+        #[validate(length(min = 5, max = 10))]
+        val: &'a Vec<String>,
+    }
+
+    let strings = vec![String::new()];
+    let s = TestStruct { val: &strings };
+    let res = s.validate();
+    assert!(res.is_err());
+    let err = res.unwrap_err();
+    let errs = err.field_errors();
+    assert!(errs.contains_key("val"));
+    assert_eq!(errs["val"].len(), 1);
+    assert_eq!(errs["val"][0].code, "length");
+    assert_eq!(errs["val"][0].params["value"], Value::Array(vec![Value::String(String::new())]));
+    assert_eq!(errs["val"][0].params["min"], 5);
+    assert_eq!(errs["val"][0].params["max"], 10);
+}


### PR DESCRIPTION
This allows validating a `&'a Vec<...>` rather than only `Vec<...>`. Similarly, this will ignore the lifetime parameter, thus allowing `&'a str` in addition to `&str`.

Example usecase: validating Diesel's `Insertable` structs.

When using diesel, it is common to have the `Insertable` structs to only be references for speed purposes, and it is the canonical way they expose in their getting started docs. This allows validating such a structure:

```rust
#[derive(Insertable, Validate)]
pub struct NewUser<'a> {
    /// User's name
    #[validate(length(min = 3, max = 128)]
    pub name: &'a str,

    /// Mainly spoken languages. Limited to 3 for simplicity for other users
    #[validate(length(min = 1, max = 3))]
    pub languages: &'a Vec<String>,
}
```