### PR TITLE
Allow passing multiple schema-level validations

### DIFF
--- a/validator_derive/src/lib.rs
+++ b/validator_derive/src/lib.rs
@@ -15,7 +15,7 @@ mod validation;
 
 use asserts::{assert_has_len, assert_has_range, assert_string_type, assert_type_matches};
 use lit::*;
-use quoting::{quote_field_validation, quote_schema_validation, FieldQuoter};
+use quoting::{quote_field_validation, quote_schema_validations, FieldQuoter};
 use validation::*;
 
 #[proc_macro_derive(Validate, attributes(validate))]
@@ -62,7 +62,7 @@ fn impl_validate(ast: &syn::DeriveInput) -> proc_macro2::TokenStream {
         }
     }
 
-    let schema_validation = quote_schema_validation(find_struct_validation(&ast.attrs));
+    let schema_validations = quote_schema_validations(&find_struct_validations(&ast.attrs));
 
     let ident = &ast.ident;
 
@@ -76,7 +76,7 @@ fn impl_validate(ast: &syn::DeriveInput) -> proc_macro2::TokenStream {
 
                 #(#validations)*
 
-                #schema_validation
+                #(#schema_validations)*
 
                 let mut result = if errors.is_empty() {
                     ::std::result::Result::Ok(())
@@ -94,95 +94,94 @@ fn impl_validate(ast: &syn::DeriveInput) -> proc_macro2::TokenStream {
 }
 
 /// Find if a struct has some schema validation and returns the info if so
-fn find_struct_validation(struct_attrs: &[syn::Attribute]) -> Option<SchemaValidation> {
+fn find_struct_validation(attr: &syn::Attribute) -> SchemaValidation {
     let error = |span: Span, msg: &str| -> ! {
         abort!(span, "Invalid schema level validation: {}", msg);
     };
 
-    for attr in struct_attrs {
-        if attr.path != parse_quote!(validate) {
-            continue;
-        }
+    if_chain! {
+        if let Ok(syn::Meta::List(syn::MetaList { ref nested, .. })) = attr.parse_meta();
+        if let syn::NestedMeta::Meta(ref item) = nested[0];
+        if let syn::Meta::List(syn::MetaList { ref path, ref nested, .. }) = *item;
 
-        if_chain! {
-            if let Ok(syn::Meta::List(syn::MetaList { ref nested, .. })) = attr.parse_meta();
-            if let syn::NestedMeta::Meta(ref item) = nested[0];
-            if let &syn::Meta::List(syn::MetaList { ref path, ref nested, .. }) = item;
-
-            then {
-                let ident = path.get_ident().unwrap();
-                if ident != "schema" {
-                    error(attr.span(), "Only `schema` is allowed as validator on a struct")
-                }
-
-                let mut function = String::new();
-                let mut skip_on_field_errors = true;
-                let mut code = None;
-                let mut message = None;
-
-                for arg in nested {
-                    if_chain! {
-                        if let syn::NestedMeta::Meta(ref item) = *arg;
-                        if let syn::Meta::NameValue(syn::MetaNameValue { ref path, ref lit, .. }) = *item;
-
-                        then {
-                            let ident = path.get_ident().unwrap();
-                            match ident.to_string().as_ref() {
-                                "function" => {
-                                    function = match lit_to_string(lit) {
-                                        Some(s) => s,
-                                        None => error(lit.span(), "invalid argument type for `function` \
-                                        : only a string is allowed"),
-                                    };
-                                },
-                                "skip_on_field_errors" => {
-                                    skip_on_field_errors = match lit_to_bool(lit) {
-                                        Some(s) => s,
-                                        None => error(lit.span(), "invalid argument type for `skip_on_field_errors` \
-                                        : only a bool is allowed"),
-                                    };
-                                },
-                                "code" => {
-                                    code = match lit_to_string(lit) {
-                                        Some(s) => Some(s),
-                                        None => error(lit.span(), "invalid argument type for `code` \
-                                        : only a string is allowed"),
-                                    };
-                                },
-                                "message" => {
-                                    message = match lit_to_string(lit) {
-                                        Some(s) => Some(s),
-                                        None => error(lit.span(), "invalid argument type for `message` \
-                                        : only a string is allowed"),
-                                    };
-                                },
-                                _ => error(lit.span(), "Unknown argument")
-                            }
-                        } else {
-                            error(arg.span(), "Unexpected args")
-                        }
-                    }
-                }
-
-                if function == "" {
-                    error(path.span(), "`function` is required");
-                }
-
-                return Some(
-                    SchemaValidation {
-                        function,
-                        skip_on_field_errors,
-                        code,
-                        message,
-                    }
-                );
-            } else {
-                error(attr.span(), "Unexpected struct validator")
+        then {
+            let ident = path.get_ident().unwrap();
+            if ident != "schema" {
+                error(attr.span(), "Only `schema` is allowed as validator on a struct")
             }
+
+            let mut function = String::new();
+            let mut skip_on_field_errors = true;
+            let mut code = None;
+            let mut message = None;
+
+            for arg in nested {
+                if_chain! {
+                    if let syn::NestedMeta::Meta(ref item) = *arg;
+                    if let syn::Meta::NameValue(syn::MetaNameValue { ref path, ref lit, .. }) = *item;
+
+                    then {
+                        let ident = path.get_ident().unwrap();
+                        match ident.to_string().as_ref() {
+                            "function" => {
+                                function = match lit_to_string(lit) {
+                                    Some(s) => s,
+                                    None => error(lit.span(), "invalid argument type for `function` \
+                                    : only a string is allowed"),
+                                };
+                            },
+                            "skip_on_field_errors" => {
+                                skip_on_field_errors = match lit_to_bool(lit) {
+                                    Some(s) => s,
+                                    None => error(lit.span(), "invalid argument type for `skip_on_field_errors` \
+                                    : only a bool is allowed"),
+                                };
+                            },
+                            "code" => {
+                                code = match lit_to_string(lit) {
+                                    Some(s) => Some(s),
+                                    None => error(lit.span(), "invalid argument type for `code` \
+                                    : only a string is allowed"),
+                                };
+                            },
+                            "message" => {
+                                message = match lit_to_string(lit) {
+                                    Some(s) => Some(s),
+                                    None => error(lit.span(), "invalid argument type for `message` \
+                                    : only a string is allowed"),
+                                };
+                            },
+                            _ => error(lit.span(), "Unknown argument")
+                        }
+                    } else {
+                        error(arg.span(), "Unexpected args")
+                    }
+                }
+            }
+
+            if function.is_empty() {
+                error(path.span(), "`function` is required");
+            }
+
+            SchemaValidation {
+                function,
+                skip_on_field_errors,
+                code,
+                message,
+            }
+        } else {
+            error(attr.span(), "Unexpected struct validator")
         }
     }
+}
 
-    None
+/// Finds all struct schema validations
+fn find_struct_validations(struct_attrs: &[syn::Attribute]) -> Vec<SchemaValidation> {
+    struct_attrs
+        .iter()
+        .filter(|attribute| attribute.path == parse_quote!(validate))
+        .map(|attribute| find_struct_validation(attribute))
+        .collect()
 }
 
 /// Find the types (as string) for each field of the struct

--- a/validator_derive/src/quoting.rs
+++ b/validator_derive/src/quoting.rs
@@ -494,38 +494,38 @@ pub fn quote_field_validation(
     }
 }
 
-pub fn quote_schema_validation(validation: Option<SchemaValidation>) -> proc_macro2::TokenStream {
-    if let Some(v) = validation {
-        let fn_ident = syn::Ident::new(&v.function, Span::call_site());
+pub fn quote_schema_validation(v: &SchemaValidation) -> proc_macro2::TokenStream {
+    let fn_ident = syn::Ident::new(&v.function, Span::call_site());
 
-        let add_message_quoted = if let Some(ref m) = v.message {
-            quote!(err.message = Some(::std::borrow::Cow::from(#m));)
-        } else {
-            quote!()
-        };
-        let mut_err_token = if v.message.is_some() { quote!(mut) } else { quote!() };
-        let quoted = quote!(
-            match #fn_ident(self) {
-                ::std::result::Result::Ok(()) => (),
-                ::std::result::Result::Err(#mut_err_token err) => {
-                    #add_message_quoted
-                    errors.add("__all__", err);
-                },
-            };
-        );
-
-        if !v.skip_on_field_errors {
-            return quoted;
-        }
-
-        quote!(
-            if errors.is_empty() {
-                #quoted
-            }
-        )
+    let add_message_quoted = if let Some(ref m) = v.message {
+        quote!(err.message = Some(::std::borrow::Cow::from(#m));)
     } else {
         quote!()
+    };
+
+    let mut_err_token = if v.message.is_some() { quote!(mut) } else { quote!() };
+
+    let quoted = quote!(
+        match #fn_ident(self) {
+            ::std::result::Result::Ok(()) => (),
+            ::std::result::Result::Err(#mut_err_token err) => {
+                #add_message_quoted
+                errors.add("__all__", err);
+            },
+        };
+    );
+
+    if !v.skip_on_field_errors {
+        return quoted;
     }
+
+    quote!(
+        #quoted
+    )
+}
+
+pub fn quote_schema_validations(validation: &[SchemaValidation]) -> Vec<proc_macro2::TokenStream> {
+    validation.iter().map(quote_schema_validation).collect()
 }
 
 pub fn quote_required_validation(


### PR DESCRIPTION
Hello, this is the re-implementation of https://github.com/Keats/validator/pull/62 to allow passing multiple schema-level validations, e.g.
```rust
fn invalid_schema_fn(_: &TestStruct) -> Result<(), ValidationError> {
    Err(ValidationError::new("meh"))
}

fn invalid_schema_fn2(_: &TestStruct) -> Result<(), ValidationError> {
    Err(ValidationError::new("meh2"))
}

#[derive(Debug, Validate)]
#[validate(schema(function = "invalid_schema_fn"))]
#[validate(schema(function = "invalid_schema_fn2"))]
struct TestStruct {
    val: String,
}
```

All tests pass and the implementation seems to be alright. The only thing that bugs me is now I'm getting a Clippy warning, which I frankly don't know how to fix yet. Macro is complex and I feel slightly lost in it. Here's the warn:
```
Unnecessary nested match
`#[warn(clippy::collapsible_match)]` on by default
for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#collapsible_matchclippycollapsible_match
lib.rs(104, 38): The outer pattern can be modified to include the inner pattern.
lib.rs(207, 9): Error originated from macro here
```