### PR TITLE
Enhancement/support u128 and i128 and their Option variants

### DIFF
--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "validator"
-version = "0.13.0"
+version = "0.13.1"
 authors = ["Vincent Prouillet <hello@vincentprouillet.com"]
 license = "MIT"
 description = "Common validation functions (email, url, length, ...) and trait - to be used with `validator_derive`"

--- a/validator/src/validation/range.rs
+++ b/validator/src/validation/range.rs
@@ -35,6 +35,8 @@ mod tests {
         assert_eq!(true, validate_range(5u8, Some(0), Some(255)));
         assert_eq!(true, validate_range(4u16, Some(0), Some(16)));
         assert_eq!(true, validate_range(6u32, Some(0), Some(23)));
+        assert_eq!(true, validate_range(18446744073709551614u64, Some(0), Some(18446744073709551615)));
+        assert_eq!(true, validate_range(340282366920938463463374607431768211454u128, Some(0), Some(340282366920938463463374607431768211455)));
     }
 
     #[test]

--- a/validator_derive/Cargo.toml
+++ b/validator_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "validator_derive"
-version = "0.13.0"
+version = "0.13.1"
 authors = ["Vincent Prouillet <hello@vincentprouillet.com"]
 license = "MIT"
 description = "Macros 1.1 implementation of #[derive(Validate)]"

--- a/validator_derive/src/asserts.rs
+++ b/validator_derive/src/asserts.rs
@@ -8,17 +8,19 @@ lazy_static! {
     pub static ref COW_TYPE: Regex = Regex::new(r"Cow<'[a-z]+,str>").unwrap();
 }
 
-pub static NUMBER_TYPES: [&str; 36] = [
+pub static NUMBER_TYPES: [&str; 40] = [
     "usize",
     "u8",
     "u16",
     "u32",
     "u64",
+    "u128",
     "isize",
     "i8",
     "i16",
     "i32",
     "i64",
+    "i128",
     "f32",
     "f64",
     "Option<usize>",
@@ -26,11 +28,13 @@ pub static NUMBER_TYPES: [&str; 36] = [
     "Option<u16>",
     "Option<u32>",
     "Option<u64>",
+    "Option<u128>",
     "Option<isize>",
     "Option<i8>",
     "Option<i16>",
     "Option<i32>",
     "Option<i64>",
+    "Option<i128>",
     "Option<f32>",
     "Option<f64>",
     "Option<Option<usize>>",

--- a/validator_derive_tests/Cargo.toml
+++ b/validator_derive_tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "validator_derive_tests"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Vincent Prouillet <hello@vincentprouillet.com>"]
 edition = "2018"
 

--- a/validator_derive_tests/tests/run-pass/range.rs
+++ b/validator_derive_tests/tests/run-pass/range.rs
@@ -24,6 +24,10 @@ struct Test {
     s10: Option<u8>,
     #[validate(range(max = 18.0))]
     s11: Option<u8>,
+    #[validate(range(min = 18, max = 22))]
+    s12: u128,
+    #[validate(range(min = 18, max = 22))]
+    s13: i128,
 }
 
 fn main() {}


### PR DESCRIPTION
Hi, so I looking at some of the issues and decided to contribute this.

These changes update the code and tests to include u128 and i128 support along with their Option variants.

I did run into something I couldnt solve though.

In my own testing this panics but not for the reason I expected
``` rust
use serde::Deserialize;

// A trait that the Validate derive will impl
use validator::{Validate, ValidationError};

#[derive(Debug, Validate, Deserialize)]
struct SignupData {
    #[validate(range(min = 18, max = 20))]
    age: u128,
}

fn main() {
    println!("Hello, world!");
    let hi = SignupData{ age: 17u128};
    println!("Hi you are {:#?} years old", hi.age); 
    hi.validate().unwrap();
}
```

The error message state:
``` rust
Hello, world!
Hi you are 17 years old
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Error("u128 is not supported", line: 0, column: 0)', /home/kaloshade/Code/validator/validator/src/types.rs:22:48
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

However the same code but with the age value set within the range, works just fine. The same thing happens with i128 Option<u128> and Option<i128>,
Another interesting note is that all the tests btw the libraries still pass weirdly enough,

I attempted to figure this out for a day or two with no luck, so I figured I'd create a PR and maybe someone more knowledgeable would be able to buff out that issue. 