### PR TITLE
Better display implementation

### DIFF
--- a/validator/src/display_impl.rs
+++ b/validator/src/display_impl.rs
@@ -1,0 +1,73 @@
+use crate::{ValidationError, ValidationErrors, ValidationErrorsKind};
+use std::fmt::{self, Write};
+
+impl fmt::Display for ValidationError {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(msg) = self.message.as_ref() {
+            write!(fmt, "{}", msg)
+        } else {
+            write!(fmt, "Validation error: {} [{:?}]", self.code, self.params)
+        }
+    }
+}
+
+fn display_errors(
+    fmt: &mut fmt::Formatter<'_>,
+    errs: &ValidationErrorsKind,
+    path: &str,
+) -> fmt::Result {
+    fn display_struct(
+        fmt: &mut fmt::Formatter<'_>,
+        errs: &ValidationErrors,
+        path: &str,
+    ) -> fmt::Result {
+        let mut full_path = String::new();
+        write!(&mut full_path, "{}.", path)?;
+        let base_len = full_path.len();
+        for (path, err) in errs.errors() {
+            write!(&mut full_path, "{}", path)?;
+            display_errors(fmt, err, &full_path)?;
+            full_path.truncate(base_len);
+        }
+        Ok(())
+    }
+
+    match errs {
+        ValidationErrorsKind::Field(errs) => {
+            write!(fmt, "{}: ", path)?;
+            let len = errs.len();
+            for (idx, err) in errs.iter().enumerate() {
+                if idx + 1 == len {
+                    write!(fmt, "{}", err)?;
+                } else {
+                    write!(fmt, "{}, ", err)?;
+                }
+            }
+            Ok(())
+        }
+        ValidationErrorsKind::Struct(errs) => display_struct(fmt, errs, path),
+        ValidationErrorsKind::List(errs) => {
+            let mut full_path = String::new();
+            write!(&mut full_path, "{}", path)?;
+            let base_len = full_path.len();
+            for (idx, err) in errs.iter() {
+                write!(&mut full_path, "[{}]", idx)?;
+                display_struct(fmt, err, &full_path)?;
+                full_path.truncate(base_len);
+            }
+            Ok(())
+        }
+    }
+}
+
+impl fmt::Display for ValidationErrors {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for (idx, (path, err)) in self.errors().iter().enumerate() {
+            display_errors(fmt, err, path)?;
+            if idx + 1 < self.errors().len() {
+                write!(fmt, "\n")?;
+            }
+        }
+        Ok(())
+    }
+}

--- a/validator/src/lib.rs
+++ b/validator/src/lib.rs
@@ -63,6 +63,7 @@
 //! validator = { version = "0.12", features = ["derive"] }
 //! ```
 
+mod display_impl;
 mod traits;
 mod types;
 mod validation;

--- a/validator/src/types.rs
+++ b/validator/src/types.rs
@@ -1,6 +1,6 @@
+use std;
 use std::borrow::Cow;
 use std::collections::{hash_map::Entry::Vacant, BTreeMap, HashMap};
-use std::{self, fmt};
 
 use serde::ser::Serialize;
 use serde_derive::{Deserialize, Serialize};
@@ -20,12 +20,6 @@ impl ValidationError {
 
     pub fn add_param<T: Serialize>(&mut self, name: Cow<'static, str>, val: &T) {
         self.params.insert(name, to_value(val).unwrap());
-    }
-}
-
-impl fmt::Display for ValidationError {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(fmt, "Validation error: {} [{:?}]", self.code, self.params)
     }
 }
 
@@ -174,11 +168,5 @@ impl std::error::Error for ValidationErrors {
     }
     fn cause(&self) -> Option<&dyn std::error::Error> {
         None
-    }
-}
-
-impl fmt::Display for ValidationErrors {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Debug::fmt(self, fmt)
     }
 }

--- a/validator/tests/display.rs
+++ b/validator/tests/display.rs
@@ -1,0 +1,52 @@
+use validator::Validate;
+
+#[derive(Validate, Clone)]
+struct Foo {
+    #[validate(length(equal = 5, message = "Please provide a valid foo!"))]
+    foo: String,
+}
+
+#[test]
+fn test_message() {
+    let bad_foo = Foo { foo: "hi!".into() };
+    let err = format!("{}", bad_foo.validate().unwrap_err());
+    assert_eq!(err, "foo: Please provide a valid foo!");
+}
+
+#[derive(Validate)]
+struct Bar {
+    #[validate]
+    bar: Foo,
+}
+
+#[derive(Validate)]
+struct DeepBar {
+    #[validate]
+    deep_bar: Bar,
+}
+
+#[test]
+fn test_nested_struct() {
+    let bad_foo = Foo { foo: "hi!".into() };
+    let bad_bar = Bar { bar: bad_foo };
+    let err = format!("{}", bad_bar.validate().unwrap_err());
+    assert_eq!(err, "bar.foo: Please provide a valid foo!");
+
+    let bad_deep_bar = DeepBar { deep_bar: bad_bar };
+    let err = format!("{}", bad_deep_bar.validate().unwrap_err());
+    assert_eq!(err, "deep_bar.bar.foo: Please provide a valid foo!");
+}
+
+#[derive(Validate)]
+struct Baz {
+    #[validate]
+    baz: Vec<Foo>,
+}
+
+#[test]
+fn test_nested_vec() {
+    let bad_foo = Foo { foo: "hi!".into() };
+    let bad_baz = Baz { baz: vec![bad_foo] };
+    let err = format!("{}", bad_baz.validate().unwrap_err());
+    assert_eq!(err, "baz[0].foo: Please provide a valid foo!");
+}

--- a/validator/tests/display.rs
+++ b/validator/tests/display.rs
@@ -1,52 +1,55 @@
-use validator::Validate;
+#[cfg(derive)]
+mod tests {
+    use validator::Validate;
 
-#[derive(Validate, Clone)]
-struct Foo {
-    #[validate(length(equal = 5, message = "Please provide a valid foo!"))]
-    foo: String,
-}
+    #[derive(Validate, Clone)]
+    struct Foo {
+        #[validate(length(equal = 5, message = "Please provide a valid foo!"))]
+        foo: String,
+    }
 
-#[test]
-fn test_message() {
-    let bad_foo = Foo { foo: "hi!".into() };
-    let err = format!("{}", bad_foo.validate().unwrap_err());
-    assert_eq!(err, "foo: Please provide a valid foo!");
-}
+    #[test]
+    fn test_message() {
+        let bad_foo = Foo { foo: "hi!".into() };
+        let err = format!("{}", bad_foo.validate().unwrap_err());
+        assert_eq!(err, "foo: Please provide a valid foo!");
+    }
 
-#[derive(Validate)]
-struct Bar {
-    #[validate]
-    bar: Foo,
-}
+    #[derive(Validate)]
+    struct Bar {
+        #[validate]
+        bar: Foo,
+    }
 
-#[derive(Validate)]
-struct DeepBar {
-    #[validate]
-    deep_bar: Bar,
-}
+    #[derive(Validate)]
+    struct DeepBar {
+        #[validate]
+        deep_bar: Bar,
+    }
 
-#[test]
-fn test_nested_struct() {
-    let bad_foo = Foo { foo: "hi!".into() };
-    let bad_bar = Bar { bar: bad_foo };
-    let err = format!("{}", bad_bar.validate().unwrap_err());
-    assert_eq!(err, "bar.foo: Please provide a valid foo!");
+    #[test]
+    fn test_nested_struct() {
+        let bad_foo = Foo { foo: "hi!".into() };
+        let bad_bar = Bar { bar: bad_foo };
+        let err = format!("{}", bad_bar.validate().unwrap_err());
+        assert_eq!(err, "bar.foo: Please provide a valid foo!");
 
-    let bad_deep_bar = DeepBar { deep_bar: bad_bar };
-    let err = format!("{}", bad_deep_bar.validate().unwrap_err());
-    assert_eq!(err, "deep_bar.bar.foo: Please provide a valid foo!");
-}
+        let bad_deep_bar = DeepBar { deep_bar: bad_bar };
+        let err = format!("{}", bad_deep_bar.validate().unwrap_err());
+        assert_eq!(err, "deep_bar.bar.foo: Please provide a valid foo!");
+    }
 
-#[derive(Validate)]
-struct Baz {
-    #[validate]
-    baz: Vec<Foo>,
-}
+    #[derive(Validate)]
+    struct Baz {
+        #[validate]
+        baz: Vec<Foo>,
+    }
 
-#[test]
-fn test_nested_vec() {
-    let bad_foo = Foo { foo: "hi!".into() };
-    let bad_baz = Baz { baz: vec![bad_foo] };
-    let err = format!("{}", bad_baz.validate().unwrap_err());
-    assert_eq!(err, "baz[0].foo: Please provide a valid foo!");
+    #[test]
+    fn test_nested_vec() {
+        let bad_foo = Foo { foo: "hi!".into() };
+        let bad_baz = Baz { baz: vec![bad_foo] };
+        let err = format!("{}", bad_baz.validate().unwrap_err());
+        assert_eq!(err, "baz[0].foo: Please provide a valid foo!");
+    }
 }


### PR DESCRIPTION
As discussed a little in #80, this PR adds a slightly nicer `Display` implementation which prints the paths to each error, and then either a generic description of the error, or the provided error message.

See the added tests for the format.