### PR TITLE
Fix parsing of schema validation function

### DIFF
--- a/validator_derive/src/quoting.rs
+++ b/validator_derive/src/quoting.rs
@@ -495,7 +495,8 @@ pub fn quote_field_validation(
 }
 
 pub fn quote_schema_validation(v: &SchemaValidation) -> proc_macro2::TokenStream {
-    let fn_ident = syn::Ident::new(&v.function, Span::call_site());
+    let fn_ident: syn::Path = syn::parse_str(&v.function).unwrap();
+    //let fn_ident = syn::Ident::new(&v.function, Span::call_site());
 
     let add_message_quoted = if let Some(ref m) = v.message {
         quote!(err.message = Some(::std::borrow::Cow::from(#m));)

--- a/validator_derive/src/quoting.rs
+++ b/validator_derive/src/quoting.rs
@@ -496,7 +496,6 @@ pub fn quote_field_validation(
 
 pub fn quote_schema_validation(v: &SchemaValidation) -> proc_macro2::TokenStream {
     let fn_ident: syn::Path = syn::parse_str(&v.function).unwrap();
-    //let fn_ident = syn::Ident::new(&v.function, Span::call_site());
 
     let add_message_quoted = if let Some(ref m) = v.message {
         quote!(err.message = Some(::std::borrow::Cow::from(#m));)

--- a/validator_derive_tests/tests/schema.rs
+++ b/validator_derive_tests/tests/schema.rs
@@ -17,6 +17,55 @@ fn can_validate_schema_fn_ok() {
     assert!(s.validate().is_ok());
 }
 
+mod some_defining_mod {
+    use validator::Validate;
+
+    #[derive(Debug, Validate)]
+    #[validate(schema(function = "crate::some_validation_mod::valid_schema_fn"))]
+    pub struct TestStructValid {
+        pub val: String,
+    }
+
+    #[derive(Debug, Validate)]
+    #[validate(schema(function = "crate::some_validation_mod::invalid_schema_fn"))]
+    pub struct TestStructInvalid {
+        pub val: String,
+    }
+}
+
+mod some_validation_mod {
+    use validator::ValidationError;
+    use crate::some_defining_mod::{TestStructValid, TestStructInvalid};
+
+    pub fn valid_schema_fn(_: &TestStructValid) -> Result<(), ValidationError> {
+        Ok(())
+    }
+
+    pub fn invalid_schema_fn(_: &TestStructInvalid) -> Result<(), ValidationError> {
+        Err(ValidationError::new("meh"))
+    }
+}
+
+#[test]
+fn can_validate_fully_qualified_fn_ok() {
+    let s = some_defining_mod::TestStructValid { val: "hello".into() };
+
+    assert!(s.validate().is_ok());
+}
+
+#[test]
+fn can_fail_fully_qualified_fn_validation() {
+    let s = some_defining_mod::TestStructInvalid { val: "hello".into() };
+
+    let res = s.validate();
+    assert!(res.is_err());
+    let err = res.unwrap_err();
+    let errs = err.field_errors();
+    assert!(errs.contains_key("__all__"));
+    assert_eq!(errs["__all__"].len(), 1);
+    assert_eq!(errs["__all__"][0].code, "meh");
+}
+
 #[test]
 fn can_validate_multiple_schema_fn_ok() {
     fn valid_schema_fn(_: &TestStruct) -> Result<(), ValidationError> {


### PR DESCRIPTION
A similar fix to: https://github.com/Keats/validator/blob/e39ec89f4026e97e3089dabc40e33129a1053a6b/validator_derive/src/quoting.rs#L376

This allows referencing schema validation functions from different modules like:
`#[validate(schema(function = "crate::some_crate::validate_something"))]`

closes: https://github.com/Keats/validator/issues/161