### PR TITLE
Derive Deserialize for ValidationErrors

### DIFF
--- a/validator/src/types.rs
+++ b/validator/src/types.rs
@@ -32,7 +32,7 @@ impl std::error::Error for ValidationError {
     }
 }
 
-#[derive(Debug, Serialize, Clone, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(untagged)]
 pub enum ValidationErrorsKind {
     Struct(Box<ValidationErrors>),
@@ -40,8 +40,8 @@ pub enum ValidationErrorsKind {
     Field(Vec<ValidationError>),
 }
 
-#[derive(Default, Debug, Serialize, Clone, PartialEq)]
-pub struct ValidationErrors(HashMap<&'static str, ValidationErrorsKind>);
+#[derive(Default, Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct ValidationErrors(HashMap<String, ValidationErrorsKind>);
 
 impl ValidationErrors {
     pub fn new() -> ValidationErrors {
@@ -106,22 +106,22 @@ impl ValidationErrors {
 
     /// Returns a map of field-level validation errors found for the struct that was validated and
     /// any of it's nested structs that are tagged for validation.
-    pub fn errors(&self) -> &HashMap<&'static str, ValidationErrorsKind> {
+    pub fn errors(&self) -> &HashMap<String, ValidationErrorsKind> {
         &self.0
     }
 
     /// Consume the struct, returning the validation errors found
-    pub fn into_errors(self) -> HashMap<&'static str, ValidationErrorsKind> {
+    pub fn into_errors(self) -> HashMap<String, ValidationErrorsKind> {
         self.0
     }
 
     /// Returns a map of only field-level validation errors found for the struct that was validated.
-    pub fn field_errors(&self) -> HashMap<&'static str, &Vec<ValidationError>> {
+    pub fn field_errors(&self) -> HashMap<String, &Vec<ValidationError>> {
         self.0
             .iter()
             .filter_map(|(k, v)| {
                 if let ValidationErrorsKind::Field(errors) = v {
-                    Some((*k, errors))
+                    Some((k.clone(), errors))
                 } else {
                     None
                 }
@@ -129,9 +129,9 @@ impl ValidationErrors {
             .collect::<HashMap<_, _>>()
     }
 
-    pub fn add(&mut self, field: &'static str, error: ValidationError) {
+    pub fn add(&mut self, field: &str, error: ValidationError) {
         if let ValidationErrorsKind::Field(ref mut vec) =
-            self.0.entry(field).or_insert_with(|| ValidationErrorsKind::Field(vec![]))
+            self.0.entry(field.to_owned()).or_insert_with(|| ValidationErrorsKind::Field(vec![]))
         {
             vec.push(error);
         } else {
@@ -144,8 +144,8 @@ impl ValidationErrors {
         self.0.is_empty()
     }
 
-    fn add_nested(&mut self, field: &'static str, errors: ValidationErrorsKind) {
-        if let Vacant(entry) = self.0.entry(field) {
+    fn add_nested(&mut self, field: &str, errors: ValidationErrorsKind) {
+        if let Vacant(entry) = self.0.entry(field.to_owned()) {
             entry.insert(errors);
         } else {
             panic!("Attempt to replace non-empty ValidationErrors entry");

--- a/validator_derive_tests/tests/compile-fail/no_nested_validations.stderr
+++ b/validator_derive_tests/tests/compile-fail/no_nested_validations.stderr
@@ -10,4 +10,4 @@ error[E0599]: no method named `validate` found for struct `Nested` in the curren
   = help: items from traits can only be used if the trait is implemented and in scope
   = note: the following trait defines an item `validate`, perhaps you need to implement it:
           candidate #1: `Validate`
-  = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the derive macro `Validate` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/validator_derive_tests/tests/complex.rs
+++ b/validator_derive_tests/tests/complex.rs
@@ -294,7 +294,7 @@ fn test_works_with_none_values() {
 
 fn unwrap_map<F>(errors: &ValidationErrors, f: F)
 where
-    F: FnOnce(HashMap<&'static str, ValidationErrorsKind>),
+    F: FnOnce(HashMap<String, ValidationErrorsKind>),
 {
     let errors = errors.clone();
     f(errors.errors().clone());

--- a/validator_derive_tests/tests/complex.rs
+++ b/validator_derive_tests/tests/complex.rs
@@ -1,6 +1,7 @@
 use lazy_static::lazy_static;
 use regex::Regex;
 use serde::Deserialize;
+use std::borrow::Cow;
 use std::collections::HashMap;
 use validator::{Validate, ValidationError, ValidationErrors, ValidationErrorsKind};
 
@@ -294,8 +295,7 @@ fn test_works_with_none_values() {
 
 fn unwrap_map<F>(errors: &ValidationErrors, f: F)
 where
-    F: FnOnce(HashMap<String, ValidationErrorsKind>),
+    F: FnOnce(HashMap<Cow<'static, str>, ValidationErrorsKind>),
 {
-    let errors = errors.clone();
     f(errors.errors().clone());
 }

--- a/validator_derive_tests/tests/nested.rs
+++ b/validator_derive_tests/tests/nested.rs
@@ -388,8 +388,7 @@ fn test_field_validations_evaluated_after_nested_validations_fails() {
 
 fn unwrap_map<F>(errors: &ValidationErrors, f: F)
 where
-    F: FnOnce(HashMap<String, ValidationErrorsKind>),
+    F: FnOnce(HashMap<Cow<'static, str>, ValidationErrorsKind>),
 {
-    let errors = errors.clone();
     f(errors.errors().clone());
 }

--- a/validator_derive_tests/tests/nested.rs
+++ b/validator_derive_tests/tests/nested.rs
@@ -388,7 +388,7 @@ fn test_field_validations_evaluated_after_nested_validations_fails() {
 
 fn unwrap_map<F>(errors: &ValidationErrors, f: F)
 where
-    F: FnOnce(HashMap<&'static str, ValidationErrorsKind>),
+    F: FnOnce(HashMap<String, ValidationErrorsKind>),
 {
     let errors = errors.clone();
     f(errors.errors().clone());


### PR DESCRIPTION
Needed to change keys to String because the Deserializer can't provide &'static str