### PR TITLE
allow any string-like value

### DIFF
--- a/validator_derive/src/asserts.rs
+++ b/validator_derive/src/asserts.rs
@@ -70,14 +70,7 @@ pub static NUMBER_TYPES: [&str; 38] = [
 ];
 
 pub fn assert_string_type(name: &str, type_name: &str, field_type: &syn::Type) {
-    if type_name != "String"
-        && type_name != "&str"
-        && !COW_TYPE.is_match(type_name)
-        && type_name != "Option<String>"
-        && type_name != "Option<Option<String>>"
-        && !(type_name.starts_with("Option<") && type_name.ends_with("str>"))
-        && !(type_name.starts_with("Option<Option<") && type_name.ends_with("str>>"))
-    {
+    if !type_name.contains("String") && !type_name.contains("str") {
         abort!(
             field_type.span(),
             "`{}` validator can only be used on String, &str, Cow<'_,str> or an Option of those",
@@ -113,17 +106,13 @@ pub fn assert_has_len(field_name: String, type_name: &str, field_type: &syn::Typ
         return;
     }
 
-    if type_name != "String"
+    if !type_name.contains("String") 
+        && !type_name.contains("str")
         && !type_name.starts_with("Vec<")
         && !type_name.starts_with("Option<Vec<")
         && !type_name.starts_with("Option<Option<Vec<")
-        && type_name != "Option<String>"
-        && type_name != "Option<Option<String>>"
         // a bit ugly
-        && !(type_name.starts_with("Option<") && type_name.ends_with("str>"))
-        && !(type_name.starts_with("Option<Option<") && type_name.ends_with("str>>"))
         && !COW_TYPE.is_match(type_name)
-        && type_name != "&str"
     {
         abort!(field_type.span(),
                 "Validator `length` can only be used on types `String`, `&str`, Cow<'_,str> or `Vec` but found `{}` for field `{}`",


### PR DESCRIPTION
As per https://github.com/Keats/validator/issues/176, I've tried to relax the validation a bit. It does work for prost Strings. Would this be acceptable?