### PR TITLE
Implement `HasLen` for map/set types

### DIFF
--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -22,6 +22,7 @@ validator_derive = { version = "0.14", path = "../validator_derive", optional = 
 card-validate = { version = "2.2", optional = true }
 phonenumber = { version = "0.3", optional = true }
 unic-ucd-common = { version = "0.9", optional = true }
+indexmap = {version = "1", features = ["serde-1"], optional = true }
 
 
 [features]

--- a/validator/src/traits.rs
+++ b/validator/src/traits.rs
@@ -1,5 +1,8 @@
 use std::borrow::Cow;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+
+#[cfg(feature = "indexmap")]
+use indexmap::{IndexMap, IndexSet};
 
 use crate::types::ValidationErrors;
 
@@ -40,7 +43,84 @@ impl<T> HasLen for Vec<T> {
         self.len() as u64
     }
 }
+
 impl<'a, T> HasLen for &'a Vec<T> {
+    fn length(&self) -> u64 {
+        self.len() as u64
+    }
+}
+
+impl<'a, K, V> HasLen for &'a HashMap<K, V> {
+    fn length(&self) -> u64 {
+        self.len() as u64
+    }
+}
+
+impl<K, V> HasLen for HashMap<K, V> {
+    fn length(&self) -> u64 {
+        self.len() as u64
+    }
+}
+
+impl<'a, T> HasLen for &'a HashSet<T> {
+    fn length(&self) -> u64 {
+        self.len() as u64
+    }
+}
+
+impl<T> HasLen for HashSet<T> {
+    fn length(&self) -> u64 {
+        self.len() as u64
+    }
+}
+
+impl<'a, K, V> HasLen for &'a BTreeMap<K, V> {
+    fn length(&self) -> u64 {
+        self.len() as u64
+    }
+}
+
+impl<K, V> HasLen for BTreeMap<K, V> {
+    fn length(&self) -> u64 {
+        self.len() as u64
+    }
+}
+
+impl<'a, T> HasLen for &'a BTreeSet<T> {
+    fn length(&self) -> u64 {
+        self.len() as u64
+    }
+}
+
+impl<T> HasLen for BTreeSet<T> {
+    fn length(&self) -> u64 {
+        self.len() as u64
+    }
+}
+
+#[cfg(feature = "indexmap")]
+impl<'a, K, V> HasLen for &'a IndexMap<K, V> {
+    fn length(&self) -> u64 {
+        self.len() as u64
+    }
+}
+
+#[cfg(feature = "indexmap")]
+impl<K, V> HasLen for IndexMap<K, V> {
+    fn length(&self) -> u64 {
+        self.len() as u64
+    }
+}
+
+#[cfg(feature = "indexmap")]
+impl<'a, T> HasLen for &'a IndexSet<T> {
+    fn length(&self) -> u64 {
+        self.len() as u64
+    }
+}
+
+#[cfg(feature = "indexmap")]
+impl<T> HasLen for IndexSet<T> {
     fn length(&self) -> u64 {
         self.len() as u64
     }

--- a/validator_derive/src/asserts.rs
+++ b/validator_derive/src/asserts.rs
@@ -138,7 +138,7 @@ pub fn assert_has_len(field_name: String, type_name: &str, field_type: &syn::Typ
         && type_name != "&str"
     {
         abort!(field_type.span(),
-                "Validator `length` can only be used on types `String`, `&str`, Cow<'_,str> or `Vec` but found `{}` for field `{}`",
+                "Validator `length` can only be used on types `String`, `&str`, Cow<'_,str>, `Vec`, or map/set types (BTree/Hash/Index) but found `{}` for field `{}`",
                 type_name, field_name
             );
     }

--- a/validator_derive/src/asserts.rs
+++ b/validator_derive/src/asserts.rs
@@ -119,6 +119,18 @@ pub fn assert_has_len(field_name: String, type_name: &str, field_type: &syn::Typ
         && !type_name.starts_with("Option<Option<Vec<")
         && type_name != "Option<String>"
         && type_name != "Option<Option<String>>"
+        && !type_name.starts_with("HashMap<")
+        && !type_name.starts_with("Option<HashMap<")
+        && !type_name.starts_with("HashSet<")
+        && !type_name.starts_with("Option<HashSet<")
+        && !type_name.starts_with("BTreeMap<")
+        && !type_name.starts_with("Option<BTreeMap<")
+        && !type_name.starts_with("BTreeSet<")
+        && !type_name.starts_with("Option<BTreeSet<")
+        && !type_name.starts_with("IndexMap<")
+        && !type_name.starts_with("Option<IndexMap<")
+        && !type_name.starts_with("IndexSet<")
+        && !type_name.starts_with("Option<IndexSet<")
         // a bit ugly
         && !(type_name.starts_with("Option<") && type_name.ends_with("str>"))
         && !(type_name.starts_with("Option<Option<") && type_name.ends_with("str>>"))

--- a/validator_derive_tests/Cargo.toml
+++ b/validator_derive_tests/Cargo.toml
@@ -11,3 +11,6 @@ serde_json = "1.0"
 trybuild = "1.0"
 regex = "1"
 lazy_static = "1"
+
+[dependencies]
+indexmap = {version = "1", features = ["serde-1"], optional = true }

--- a/validator_derive_tests/tests/compile-fail/length/wrong_type.stderr
+++ b/validator_derive_tests/tests/compile-fail/length/wrong_type.stderr
@@ -1,4 +1,4 @@
-error: Validator `length` can only be used on types `String`, `&str`, Cow<'_,str> or `Vec` but found `usize` for field `s`
+error: Validator `length` can only be used on types `String`, `&str`, Cow<'_,str>, `Vec`, or map/set types (BTree/Hash/Index) but found `usize` for field `s`
  --> $DIR/wrong_type.rs:6:8
   |
 6 |     s: usize,

--- a/validator_derive_tests/tests/length.rs
+++ b/validator_derive_tests/tests/length.rs
@@ -149,3 +149,29 @@ fn can_validate_ref_for_length() {
     assert_eq!(errs["val"][0].params["min"], 5);
     assert_eq!(errs["val"][0].params["max"], 10);
 }
+
+#[cfg(feature = "indexmap")]
+#[test]
+fn can_validate_set_ref_for_length() {
+    use indexmap::{indexset, IndexSet};
+    use serde_json::Value;
+
+    #[derive(Debug, Validate)]
+    struct TestStruct<'a> {
+        #[validate(length(min = 5, max = 10))]
+        val: &'a IndexSet<String>,
+    }
+
+    let strings = indexset! {String::new()};
+    let s = TestStruct { val: &strings };
+    let res = s.validate();
+    assert!(res.is_err());
+    let err = res.unwrap_err();
+    let errs = err.field_errors();
+    assert!(errs.contains_key("val"));
+    assert_eq!(errs["val"].len(), 1);
+    assert_eq!(errs["val"][0].code, "length");
+    assert_eq!(errs["val"][0].params["value"], Value::Array(vec![Value::String(String::new())]));
+    assert_eq!(errs["val"][0].params["min"], 5);
+    assert_eq!(errs["val"][0].params["max"], 10);
+}


### PR DESCRIPTION
This PR implements `HasLen` on all std::collection Map/Set types along with an optional feature to support the popular `indexmap` crate.