### PR TITLE
Give possibility to pass `arg` to `schema` validator

### DIFF
--- a/validator_derive/src/quoting.rs
+++ b/validator_derive/src/quoting.rs
@@ -510,6 +510,13 @@ pub fn quote_validator(
 pub fn quote_schema_validation(v: &SchemaValidation) -> proc_macro2::TokenStream {
     let fn_ident: syn::Path = syn::parse_str(&v.function).unwrap();
 
+    let arg_quoted = if let Some(ref args) = v.args {
+        let arg_type = &args.arg_access;
+        quote!(self, #arg_type)
+    } else {
+        quote!(self)
+    };
+
     let add_message_quoted = if let Some(ref m) = v.message {
         quote!(err.message = Some(::std::borrow::Cow::from(#m));)
     } else {
@@ -519,7 +526,7 @@ pub fn quote_schema_validation(v: &SchemaValidation) -> proc_macro2::TokenStream
     let mut_err_token = if v.message.is_some() { quote!(mut) } else { quote!() };
 
     let quoted = quote!(
-        match #fn_ident(self) {
+        match #fn_ident(#arg_quoted) {
             ::std::result::Result::Ok(()) => (),
             ::std::result::Result::Err(#mut_err_token err) => {
                 #add_message_quoted

--- a/validator_derive/src/validation.rs
+++ b/validator_derive/src/validation.rs
@@ -9,6 +9,7 @@ use crate::{asserts::assert_custom_arg_type, lit::*};
 #[derive(Debug)]
 pub struct SchemaValidation {
     pub function: String,
+    pub args: Option<CustomArgument>,
     pub skip_on_field_errors: bool,
     pub code: Option<String>,
     pub message: Option<String>,

--- a/validator_derive_tests/tests/schema_args.rs
+++ b/validator_derive_tests/tests/schema_args.rs
@@ -1,0 +1,109 @@
+use std::ops::AddAssign;
+
+use validator::{Validate, ValidateArgs, ValidationError};
+
+struct CustomStruct {
+    pub counter: i32,
+}
+
+#[test]
+fn validate_schema_fn_reference_with_lifetime_ok() {
+    fn valid_reference_with_lifetime(
+        _: &TestStruct,
+        arg: &mut CustomStruct,
+    ) -> Result<(), ValidationError> {
+        arg.counter += 1;
+        Ok(())
+    }
+
+    #[allow(dead_code)]
+    #[derive(Debug, Validate)]
+    #[validate(schema(function = "valid_reference_with_lifetime", arg = "&'v_a mut CustomStruct"))]
+    struct TestStruct {
+        value: String,
+    }
+
+    let s = TestStruct { value: "Hello World".to_string() };
+    let mut cs = CustomStruct { counter: 0 };
+    assert!(s.validate_args(&mut cs).is_ok());
+    assert_eq!(cs.counter, 1);
+}
+
+#[test]
+fn validate_schema_fn_tuple_err() {
+    fn invalid_custom_tuple(_: &TestStruct, _arg: (i64, i64)) -> Result<(), ValidationError> {
+        Err(ValidationError::new("meh"))
+    }
+
+    #[allow(dead_code)]
+    #[derive(Debug, Validate)]
+    #[validate(schema(function = "invalid_custom_tuple", arg = "(i64, i64)"))]
+    struct TestStruct {
+        value: String,
+    }
+
+    let s = TestStruct { value: "Hello World".to_string() };
+    assert!(s.validate_args((77, 555)).is_err());
+}
+
+#[test]
+fn invalidate_schema_fn_complex_arg_err() {
+    fn invalid_validation_complex_args<'a, T: AddAssign>(
+        _: &TestStruct,
+        arg: (&'a mut CustomStruct, &'a mut T, T),
+    ) -> Result<(), ValidationError> {
+        arg.0.counter += 1;
+        *arg.1 += arg.2;
+        Err(ValidationError::new("meh"))
+    }
+
+    #[allow(dead_code)]
+    #[derive(Debug, Validate)]
+    #[validate(schema(
+        function = "invalid_validation_complex_args",
+        arg = "(&'v_a mut CustomStruct, &'v_a mut i32, i32)"
+    ))]
+    struct TestStruct {
+        value: String,
+    }
+
+    let s = TestStruct { value: "Hello World".to_string() };
+    let mut cs = CustomStruct { counter: 0 };
+    let mut value = 10;
+    assert!(s.validate_args((&mut cs, &mut value, 5)).is_err());
+    assert_eq!(cs.counter, 1);
+    assert_eq!(value, 15);
+}
+
+#[test]
+fn validate_schema_multiple_fn_with_args_ok() {
+    fn valid_reference_with_lifetime(
+        _: &TestStruct,
+        arg: &mut CustomStruct,
+    ) -> Result<(), ValidationError> {
+        arg.counter += 1;
+        Ok(())
+    }
+
+    fn invalid_custom_tuple(_: &TestStruct, _arg: (i64, i64)) -> Result<(), ValidationError> {
+        Err(ValidationError::new("meh"))
+    }
+
+    #[allow(dead_code)]
+    #[derive(Debug, Validate)]
+    #[validate(schema(function = "valid_reference_with_lifetime", arg = "&'v_a mut CustomStruct"))]
+    #[validate(schema(function = "invalid_custom_tuple", arg = "(i64, i64)"))]
+    struct TestStruct {
+        value: String,
+        other_value: String,
+    }
+
+    let s = TestStruct {
+        value: "Hello World".to_string(),
+        other_value: "I'm different from value".to_string(),
+    };
+
+    let mut cs = CustomStruct { counter: 0 };
+    assert!(s.validate_args((&mut cs, (123, 456))).is_err());
+    assert_eq!(cs.counter, 1);
+}


### PR DESCRIPTION
Hello everyone.

I add the possibility to pass `arg` to the `schema` validator, the same way it is done for the `custom` validator.

Once again, I'm not sure it was the way to do it, but at least it is there.