### PR TITLE
feat: rocket feature for rocket json validation

### DIFF
--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -22,6 +22,9 @@ validator_derive = { version = "0.14", path = "../validator_derive", optional = 
 card-validate = { version = "2.2", optional = true }
 phonenumber = { version = "0.3", optional = true }
 unic-ucd-common = { version = "0.9", optional = true }
+rocket = { version = "0.5.0-rc.1", optional = true, default-features = false, features = [
+    "json",
+] }
 
 
 [features]

--- a/validator/src/traits.rs
+++ b/validator/src/traits.rs
@@ -102,6 +102,14 @@ impl<T: Validate> Validate for &T {
     }
 }
 
+/// Implements Validate for Rockets `Json` type
+#[cfg(feature="rocket")]
+impl<T: Validate> Validate for rocket::serde::json::Json<T> {
+    fn validate(&self) -> Result<(), ValidationErrors> {
+        T::validate(&self.0)
+    }
+}
+
 /// This trait will be implemented by deriving `Validate`. This implementation can take one
 /// argument and pass this on to custom validators. The default `Args` type will be `()` if
 /// there is no custom validation with defined arguments.


### PR DESCRIPTION
Lovely crate,

I would like to create a validation extension for rocket which has a type called `Json`. Since it's kind of a tricky one I would like to have type `T` validated for `Json<T>`.

The code is hidden behind the feature flag `rocket` and doesn't include default features of rocket, only the needed basics. I didn't meantion it in some documentations due to it being a "behind the scenes" thing as Request guards and much more would be needed to be implemented to work with rocket. As you can see [here](https://github.com/somehowchris/rocket-validation)

I'm opening this PR since rockets typing system doesn't allow for implementsions in third party crates