### PR TITLE
Allow unsupported_field_type to be ignored

### DIFF
--- a/validator_derive/src/lib.rs
+++ b/validator_derive/src/lib.rs
@@ -342,12 +342,7 @@ fn find_fields_type(fields: &[syn::Field]) -> HashMap<String, String> {
             _ => {
                 let mut field_type = proc_macro2::TokenStream::new();
                 field.ty.to_tokens(&mut field_type);
-                abort!(
-                    field.ty.span(),
-                    "Type `{}` of field `{}` not supported",
-                    field_type,
-                    field_ident
-                )
+                field_type.to_string().replace(' ', "")
             }
         };
 

--- a/validator_derive_tests/tests/compile-fail/unsupported_field_type.rs
+++ b/validator_derive_tests/tests/compile-fail/unsupported_field_type.rs
@@ -1,8 +1,0 @@
-use validator::Validate;
-
-#[derive(Validate)]
-struct Values {
-    values: [u8; 10],
-}
-
-fn main() {}

--- a/validator_derive_tests/tests/compile-fail/unsupported_field_type.stderr
+++ b/validator_derive_tests/tests/compile-fail/unsupported_field_type.stderr
@@ -1,5 +1,0 @@
-error: Type `[u8 ; 10]` of field `values` not supported
- --> $DIR/unsupported_field_type.rs:5:13
-  |
-5 |     values: [u8; 10],
-  |             ^^^^^^^^

--- a/validator_derive_tests/tests/run-pass/unsupported_field_type.rs
+++ b/validator_derive_tests/tests/run-pass/unsupported_field_type.rs
@@ -1,0 +1,8 @@
+use validator::Validate;
+
+#[derive(Validate)]
+struct Test {
+    s: [u8; 11],
+}
+
+fn main() {}

--- a/validator_derive_tests/tests/unsupported_array.rs
+++ b/validator_derive_tests/tests/unsupported_array.rs
@@ -1,4 +1,11 @@
-use validator::Validate;
+use validator::{Validate, ValidationError};
+
+fn valid_custom_fn(arr: &[u8; 2]) -> Result<(), ValidationError> {
+    match arr[0] == 1 {
+        true => Ok(()),
+        false => Err(ValidationError::new("meh")),
+    }
+}
 
 #[test]
 fn can_validate_valid_email_with_unsupported_array() {
@@ -7,10 +14,47 @@ fn can_validate_valid_email_with_unsupported_array() {
         #[validate(email)]
         val: String,
         #[allow(dead_code)]
-        array: [u8; 32],
+        array: [u8; 2],
     }
 
-    let s = TestStruct { val: "bob@bob.com".to_string(), array: [0u8; 32] };
+    let s = TestStruct { val: "bob@bob.com".to_string(), array: [0u8; 2] };
 
     assert!(s.validate().is_ok());
+}
+
+#[test]
+fn can_validate_custom_with_unsupported_array() {
+    #[derive(Debug, Validate)]
+    struct TestStruct {
+        #[validate(email)]
+        val: String,
+        #[validate(custom = "valid_custom_fn")]
+        array: [u8; 2],
+    }
+
+    let s = TestStruct { val: "bob@bob.com".to_string(), array: [1u8, 1u8] };
+
+    assert!(s.validate().is_ok());
+}
+
+#[test]
+fn can_fail_custom_with_unsupported_array() {
+    #[derive(Debug, Validate)]
+    struct TestStruct {
+        #[validate(email)]
+        val: String,
+        #[validate(custom = "valid_custom_fn")]
+        array: [u8; 2],
+    }
+
+    let s = TestStruct { val: "bob@bob.com".to_string(), array: [0u8, 1u8] };
+
+    let res = s.validate();
+    assert!(res.is_err());
+    let err = res.unwrap_err();
+    let errs = err.field_errors();
+    assert!(errs.contains_key("array"));
+    assert_eq!(errs["array"].len(), 1);
+    assert_eq!(errs["array"][0].code, "meh");
+    assert_eq!(errs["array"][0].params["value"][0], 0);
 }

--- a/validator_derive_tests/tests/unsupported_array.rs
+++ b/validator_derive_tests/tests/unsupported_array.rs
@@ -1,0 +1,16 @@
+use validator::Validate;
+
+#[test]
+fn can_validate_valid_email_with_unsupported_array() {
+    #[derive(Debug, Validate)]
+    struct TestStruct {
+        #[validate(email)]
+        val: String,
+        #[allow(dead_code)]
+        array: [u8; 32],
+    }
+
+    let s = TestStruct { val: "bob@bob.com".to_string(), array: [0u8; 32] };
+
+    assert!(s.validate().is_ok());
+}


### PR DESCRIPTION
@Keats,

First of all, It is my first time dealing with macro in rust.

Maybe it is not the best way to do it. But, I created a new skip validator.
- Alternative is to ignore at compile time (inside the macro).

I would like some code review on:
- General skip purpose
- Necessary/Required tests

If you have any hint, you are welcome ;-)

Related to: https://github.com/Keats/validator/issues/182 