### PR TITLE
Add `sensitive` validator meta parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ match signup_data.validate() {
 
 A validation on an `Option<_>` field will be executed on the contained type if the option is `Some`. The `validate()`
  method returns a `Result<(), ValidationErrors>`. In the case of an invalid result, the `ValidationErrors` instance includes
-a map of errors keyed against the struct's field names. Errors may be represented in three ways, as described by the 
+a map of errors keyed against the struct's field names. Errors may be represented in three ways, as described by the
 `ValidationErrorsKind` enum:
 
 ```rust
@@ -339,13 +339,14 @@ if an error happened while validating the struct fields.
 
 Any error on the struct level validation will appear in the key `__all__` of the hashmap of errors.
 
-## Message and code
+## `message`, `code`, and `sensitive`
 
-Each validator can take 2 optional arguments in addition to their own arguments:
+Each validator can take 3 optional arguments in addition to their own arguments:
 
 - `message`: a message to go with the error, for example if you want to do i18n
 - `code`: each validator has a default error code (for example the `regex` validator code is `regex`) but it can be overriden
 if necessary, mainly needed for the `custom` validator
+- `sensitive`: when set to `true`, the field value will be omitted from validation errors, and can be used for fields with sensitive data such as passwords
 
 Note that these arguments can't be applied to nested validation calls with `#[validate]`.
 
@@ -371,9 +372,14 @@ For example, the following attributes all work:
 #[validate(contains(pattern = "pattern_str", message = "message_str"))]
 #[validate(must_match(other = "match_value", message = "message_str"))]
 
-// both attributes
+// sensitive attribute
+#[validate(length(min = 8, max = 255, sensitive = true))]
+#[validate(credit_card(sensitive = true))]
+
+// multiple attributes
 #[validate(url(message = "message", code = "code_str"))]
 #[validate(email(code = "code_str", message = "message"))]
 #[validate(custom(function = "custom_fn", code = "code_str", message = "message_str"))]
+#[validate(length(min = 8, code = "code_str", message = "message_str", sensitive = true))]
 
 ```

--- a/validator_derive/src/lib.rs
+++ b/validator_derive/src/lib.rs
@@ -224,6 +224,7 @@ fn find_struct_validation(attr: &syn::Attribute) -> SchemaValidation {
             let mut code = None;
             let mut message = None;
             let mut args = None;
+            let mut sensitive = false;
 
             for arg in nested {
                 if_chain! {
@@ -278,6 +279,13 @@ fn find_struct_validation(attr: &syn::Attribute) -> SchemaValidation {
                                     None => error(lit.span(), "invalid argument type for `arg` of `custom` validator: expected a string")
                                 };
                             },
+                            "sensitive" => {
+                                sensitive = match lit_to_bool(lit) {
+                                    Some(b) => b,
+                                    None => error(lit.span(), "invalid argument type for `sensitive` \
+                                    : only `true` or `false` are allowed"),
+                                };
+                            }
                             _ => error(lit.span(), "Unknown argument")
                         }
                     } else {
@@ -296,6 +304,7 @@ fn find_struct_validation(attr: &syn::Attribute) -> SchemaValidation {
                 skip_on_field_errors,
                 code,
                 message,
+                sensitive
             }
         } else {
             error(attr.span(), "Unexpected struct validator")

--- a/validator_derive_tests/tests/compile-fail/custom/multiple_types_in_arg.stderr
+++ b/validator_derive_tests/tests/compile-fail/custom/multiple_types_in_arg.stderr
@@ -1,6 +1,6 @@
 error: Invalid attribute #[validate] on field `s`: invalid argument type for `arg` of `custom` validator: The string has to be a single type.
-(Tip: You can combine multiple types into one tuple.)
- --> $DIR/multiple_types_in_arg.rs:5:55
+       (Tip: You can combine multiple types into one tuple.)
+ --> tests/compile-fail/custom/multiple_types_in_arg.rs:5:55
   |
 5 |     #[validate(custom(function = "hello_world", arg = "i64, i64"))]
   |                                                       ^^^^^^^^^^

--- a/validator_derive_tests/tests/compile-fail/unnamed_fields.stderr
+++ b/validator_derive_tests/tests/compile-fail/unnamed_fields.stderr
@@ -1,8 +1,8 @@
 error: struct has unnamed fields
 
-  = help: #[derive(Validate)] can only be used on structs with named fields
+         = help: #[derive(Validate)] can only be used on structs with named fields
 
- --> $DIR/unnamed_fields.rs:4:19
+ --> tests/compile-fail/unnamed_fields.rs:4:19
   |
 4 | struct TupleStruct(String);
   |                   ^^^^^^^^

--- a/validator_derive_tests/tests/contains.rs
+++ b/validator_derive_tests/tests/contains.rs
@@ -66,3 +66,20 @@ fn can_specify_message_for_contains() {
     assert_eq!(errs["val"].len(), 1);
     assert_eq!(errs["val"][0].clone().message.unwrap(), "oops");
 }
+
+#[test]
+fn can_specify_sensitive_for_contains() {
+    #[derive(Debug, Validate)]
+    struct TestStruct {
+        #[validate(contains(pattern = "he", sensitive = true))]
+        val: String,
+    }
+    let s = TestStruct { val: String::new() };
+    let res = s.validate();
+    assert!(res.is_err());
+    let err = res.unwrap_err();
+    let errs = err.field_errors();
+    assert!(errs.contains_key("val"));
+    assert_eq!(errs["val"].len(), 1);
+    assert!(!errs["val"][0].params.contains_key("value"));
+}

--- a/validator_derive_tests/tests/credit_card.rs
+++ b/validator_derive_tests/tests/credit_card.rs
@@ -65,3 +65,20 @@ fn can_specify_message_for_credit_card() {
     assert_eq!(errs["val"].len(), 1);
     assert_eq!(errs["val"][0].clone().message.unwrap(), "oops");
 }
+
+#[test]
+fn can_specify_sensitive_for_credit_card() {
+    #[derive(Debug, Validate)]
+    struct TestStruct {
+        #[validate(credit_card(sensitive = true))]
+        val: String,
+    }
+    let s = TestStruct { val: "bob".to_string() };
+    let res = s.validate();
+    assert!(res.is_err());
+    let err = res.unwrap_err();
+    let errs = err.field_errors();
+    assert!(errs.contains_key("val"));
+    assert_eq!(errs["val"].len(), 1);
+    assert!(!errs["val"][0].params.contains_key("value"));
+}

--- a/validator_derive_tests/tests/custom.rs
+++ b/validator_derive_tests/tests/custom.rs
@@ -56,3 +56,20 @@ fn can_specify_message_for_custom_fn() {
     assert_eq!(errs["val"].len(), 1);
     assert_eq!(errs["val"][0].clone().message.unwrap(), "oops");
 }
+
+#[test]
+fn can_specify_sensitive_for_custom_fn() {
+    #[derive(Debug, Validate)]
+    struct TestStruct {
+        #[validate(custom(function = "invalid_custom_fn", sensitive = true))]
+        val: String,
+    }
+    let s = TestStruct { val: String::new() };
+    let res = s.validate();
+    assert!(res.is_err());
+    let err = res.unwrap_err();
+    let errs = err.field_errors();
+    assert!(errs.contains_key("val"));
+    assert_eq!(errs["val"].len(), 1);
+    assert!(!errs["val"][0].params.contains_key("value"));
+}

--- a/validator_derive_tests/tests/email.rs
+++ b/validator_derive_tests/tests/email.rs
@@ -65,3 +65,20 @@ fn can_specify_message_for_email() {
     assert_eq!(errs["val"].len(), 1);
     assert_eq!(errs["val"][0].clone().message.unwrap(), "oops");
 }
+
+#[test]
+fn can_specify_sensitive_for_email() {
+    #[derive(Debug, Validate)]
+    struct TestStruct {
+        #[validate(email(sensitive = true))]
+        val: String,
+    }
+    let s = TestStruct { val: "bob".to_string() };
+    let res = s.validate();
+    assert!(res.is_err());
+    let err = res.unwrap_err();
+    let errs = err.field_errors();
+    assert!(errs.contains_key("val"));
+    assert_eq!(errs["val"].len(), 1);
+    assert!(!errs["val"][0].params.contains_key("value"));
+}

--- a/validator_derive_tests/tests/length.rs
+++ b/validator_derive_tests/tests/length.rs
@@ -127,6 +127,23 @@ fn can_specify_message_for_length() {
 }
 
 #[test]
+fn can_specify_sensitive_for_length() {
+    #[derive(Debug, Validate)]
+    struct TestStruct {
+        #[validate(length(min = 5, max = 10, sensitive = true))]
+        val: String,
+    }
+    let s = TestStruct { val: String::new() };
+    let res = s.validate();
+    assert!(res.is_err());
+    let err = res.unwrap_err();
+    let errs = err.field_errors();
+    assert!(errs.contains_key("val"));
+    assert_eq!(errs["val"].len(), 1);
+    assert!(!errs["val"][0].params.contains_key("value"));
+}
+
+#[test]
 fn can_validate_ref_for_length() {
     use serde_json::Value;
 

--- a/validator_derive_tests/tests/must_match.rs
+++ b/validator_derive_tests/tests/must_match.rs
@@ -71,3 +71,21 @@ fn can_specify_message_for_must_match() {
     assert_eq!(errs["val"].len(), 1);
     assert_eq!(errs["val"][0].clone().message.unwrap(), "oops");
 }
+
+#[test]
+fn can_specify_sensitive_for_must_match() {
+    #[derive(Debug, Validate)]
+    struct TestStruct {
+        #[validate(must_match(other = "val2", sensitive = true))]
+        val: String,
+        val2: String,
+    }
+    let s = TestStruct { val: "bob".to_string(), val2: "bobb".to_string() };
+    let res = s.validate();
+    assert!(res.is_err());
+    let err = res.unwrap_err();
+    let errs = err.field_errors();
+    assert!(errs.contains_key("val"));
+    assert_eq!(errs["val"].len(), 1);
+    assert!(!errs["val"][0].params.contains_key("value"));
+}

--- a/validator_derive_tests/tests/non_control.rs
+++ b/validator_derive_tests/tests/non_control.rs
@@ -65,3 +65,20 @@ fn can_specify_message_for_non_control_character() {
     assert_eq!(errs["val"].len(), 1);
     assert_eq!(errs["val"][0].clone().message.unwrap(), "oops");
 }
+
+#[test]
+fn can_specify_sensitive_for_non_control_character() {
+    #[derive(Debug, Validate)]
+    struct TestStruct {
+        #[validate(non_control_character(sensitive = true))]
+        val: String,
+    }
+    let s = TestStruct { val: "\u{009F}하늘".to_string() };
+    let res = s.validate();
+    assert!(res.is_err());
+    let err = res.unwrap_err();
+    let errs = err.field_errors();
+    assert!(errs.contains_key("val"));
+    assert_eq!(errs["val"].len(), 1);
+    assert!(!errs["val"][0].params.contains_key("value"));
+}

--- a/validator_derive_tests/tests/phone.rs
+++ b/validator_derive_tests/tests/phone.rs
@@ -65,3 +65,20 @@ fn can_specify_message_for_phone() {
     assert_eq!(errs["val"].len(), 1);
     assert_eq!(errs["val"][0].clone().message.unwrap(), "oops");
 }
+
+#[test]
+fn can_specify_sensitive_for_phone() {
+    #[derive(Debug, Validate)]
+    struct TestStruct {
+        #[validate(phone(sensitive = true))]
+        val: String,
+    }
+    let s = TestStruct { val: "bob".to_string() };
+    let res = s.validate();
+    assert!(res.is_err());
+    let err = res.unwrap_err();
+    let errs = err.field_errors();
+    assert!(errs.contains_key("val"));
+    assert_eq!(errs["val"].len(), 1);
+    assert!(!errs["val"][0].params.contains_key("value"));
+}

--- a/validator_derive_tests/tests/range.rs
+++ b/validator_derive_tests/tests/range.rs
@@ -138,6 +138,23 @@ fn can_specify_message_for_range() {
 }
 
 #[test]
+fn can_specify_sensitive_for_range() {
+    #[derive(Debug, Validate)]
+    struct TestStruct {
+        #[validate(range(min = 5, max = 10, sensitive = true))]
+        val: usize,
+    }
+    let s = TestStruct { val: 1 };
+    let res = s.validate();
+    assert!(res.is_err());
+    let err = res.unwrap_err();
+    let errs = err.field_errors();
+    assert!(errs.contains_key("val"));
+    assert_eq!(errs["val"].len(), 1);
+    assert!(!errs["val"][0].params.contains_key("value"));
+}
+
+#[test]
 fn can_pass_reference_as_validate() {
     // This tests that the blanket Validate implementation on
     // `&T where T:Validate` works properly

--- a/validator_derive_tests/tests/regex.rs
+++ b/validator_derive_tests/tests/regex.rs
@@ -71,3 +71,20 @@ fn can_specify_message_for_regex() {
     assert_eq!(errs["val"].len(), 1);
     assert_eq!(errs["val"][0].clone().message.unwrap(), "oops");
 }
+
+#[test]
+fn can_specify_sensitive_for_regex() {
+    #[derive(Debug, Validate)]
+    struct TestStruct {
+        #[validate(regex(path = "crate::RE2", sensitive = true))]
+        val: String,
+    }
+    let s = TestStruct { val: "2".to_string() };
+    let res = s.validate();
+    assert!(res.is_err());
+    let err = res.unwrap_err();
+    let errs = err.field_errors();
+    assert!(errs.contains_key("val"));
+    assert_eq!(errs["val"].len(), 1);
+    assert!(!errs["val"][0].params.contains_key("value"));
+}

--- a/validator_derive_tests/tests/url.rs
+++ b/validator_derive_tests/tests/url.rs
@@ -67,3 +67,20 @@ fn can_specify_message_for_url() {
     assert_eq!(errs["val"].len(), 1);
     assert_eq!(errs["val"][0].clone().message.unwrap(), "oops");
 }
+
+#[test]
+fn can_specify_sensitive_for_url() {
+    #[derive(Debug, Validate)]
+    struct TestStruct {
+        #[validate(url(sensitive = true))]
+        val: String,
+    }
+    let s = TestStruct { val: "bob".to_string() };
+    let res = s.validate();
+    assert!(res.is_err());
+    let err = res.unwrap_err();
+    let errs = err.field_errors();
+    assert!(errs.contains_key("val"));
+    assert_eq!(errs["val"].len(), 1);
+    assert!(!errs["val"][0].params.contains_key("value"));
+}


### PR DESCRIPTION
Often, struct fields contain sensitive data which should never be displayed once the struct has been initially constructed or user input has been parsed (e.g. passwords and credit card numbers). This is especially problematic when logging validation errors as the invalid values may be potentially leaked in plaintext to logs.
    
This change adds a boolean `sensitive` validator "meta parameter" similar to the `message` and `code` parameters. This marks a field as sensitive such that the value should not be included in validation errors.

Resolves #157 