### PR TITLE
Update regex to `1.5.5`

### DIFF
--- a/validator_derive/Cargo.toml
+++ b/validator_derive/Cargo.toml
@@ -24,7 +24,7 @@ proc-macro2 = "1"
 proc-macro-error = "1"
 if_chain = "1"
 validator_types = { version = "0.14", path = "../validator_types" }
-regex = "1"
+regex = "1.5.5"
 lazy_static = "1"
 
 


### PR DESCRIPTION
Update regex to `1.5.5` based on [security advisory](https://blog.rust-lang.org/2022/03/08/cve-2022-24713.html)