### PR TITLE
feat: adds `Deserialize` derives to `ValidationErrors` and `ValidationErrorsKind`

### DIFF
--- a/validator/src/types.rs
+++ b/validator/src/types.rs
@@ -31,7 +31,7 @@ impl std::error::Error for ValidationError {
     }
 }
 
-#[derive(Debug, Serialize, Clone, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(untagged)]
 pub enum ValidationErrorsKind {
     Struct(Box<ValidationErrors>),
@@ -39,7 +39,7 @@ pub enum ValidationErrorsKind {
     Field(Vec<ValidationError>),
 }
 
-#[derive(Default, Debug, Serialize, Clone, PartialEq)]
+#[derive(Default, Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct ValidationErrors(HashMap<&'static str, ValidationErrorsKind>);
 
 impl ValidationErrors {


### PR DESCRIPTION
As I tried to deserialize the `ValidationErrors` struct I noticed that `ValidationError` is deserializable but not `ValidationErrors`