### PR TITLE
Remove validator_types dep from main validator crate.

### DIFF
--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -17,7 +17,6 @@ idna = "0.2"
 serde = "1"
 serde_derive = "1"
 serde_json = "1"
-validator_types = { version = "0.14", path = "../validator_types" }
 validator_derive = { version = "0.14", path = "../validator_derive", optional = true }
 card-validate = { version = "2.2", optional = true }
 phonenumber = { version = "0.3", optional = true }
@@ -26,7 +25,7 @@ indexmap = {version = "1", features = ["serde-1"], optional = true }
 
 
 [features]
-phone = ["phonenumber", "validator_derive/phone", "validator_types/phone"]
-card = ["card-validate", "validator_derive/card", "validator_types/card"]
-unic = ["unic-ucd-common", "validator_derive/unic", "validator_types/unic"]
+phone = ["phonenumber", "validator_derive/phone"]
+card = ["card-validate", "validator_derive/card"]
+unic = ["unic-ucd-common", "validator_derive/unic"]
 derive = ["validator_derive"]

--- a/validator/src/lib.rs
+++ b/validator/src/lib.rs
@@ -83,7 +83,6 @@ pub use validation::range::validate_range;
 
 pub use validation::required::validate_required;
 pub use validation::urls::validate_url;
-pub use validation::Validator;
 
 pub use traits::{Contains, HasLen, Validate, ValidateArgs};
 pub use types::{ValidationError, ValidationErrors, ValidationErrorsKind};

--- a/validator/src/validation/mod.rs
+++ b/validator/src/validation/mod.rs
@@ -12,5 +12,3 @@ pub mod phone;
 pub mod range;
 pub mod required;
 pub mod urls;
-
-pub use validator_types::Validator;


### PR DESCRIPTION
This removes the transitive dependency on proc_macro, allowing the
crate to be cross compiled when a target proc_macro is not available.