### PR TITLE
Remove transitive proc-macro dep from validator crate.

### DIFF
--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -17,13 +17,12 @@ idna = "0.2"
 serde = "1"
 serde_derive = "1"
 serde_json = "1"
-validator_types = { version = "0.14", path = "../validator_types" }
+validator_types = { version = "0.14", path = "../validator_types", default-features=false }
 validator_derive = { version = "0.14", path = "../validator_derive", optional = true }
 card-validate = { version = "2.2", optional = true }
 phonenumber = { version = "0.3", optional = true }
 unic-ucd-common = { version = "0.9", optional = true }
 indexmap = {version = "1", features = ["serde-1"], optional = true }
-
 
 [features]
 phone = ["phonenumber", "validator_derive/phone", "validator_types/phone"]

--- a/validator_types/Cargo.toml
+++ b/validator_types/Cargo.toml
@@ -9,12 +9,13 @@ repository = "https://github.com/Keats/validator"
 keywords = ["validation", "api", "validator"]
 edition = "2018"
 
-
 [features]
+default = ["proc-macro"]
 phone = []
 card = []
 unic = []
+proc-macro = ["proc-macro2/proc-macro", "syn/proc-macro"]
 
 [dependencies]
-syn = { version = "1", features = ["extra-traits"] }
+syn = { version = "1", features = ["extra-traits"], deault-features=false }
 proc-macro2 = "1"


### PR DESCRIPTION
Alternative solution to https://github.com/Keats/validator/pull/206. Instead of completely removing dependency on crate, just remove transitive dependency on `proc_macro` crate.