### PR TITLE
Email length validation before regex

### DIFF
--- a/validator/src/validation/email.rs
+++ b/validator/src/validation/email.rs
@@ -33,13 +33,13 @@ where
     let user_part = parts[1];
     let domain_part = parts[0];
 
-	// validate the length of each part of the email, BEFORE doing the regex
-	// according to RFC5321 the max length of the local part is 64 characters
-	// and the max length of the domain part is 255 characters
-	// https://datatracker.ietf.org/doc/html/rfc5321#section-4.5.3.1.1
-	if user_part.length() > 64 || domain_part.length() > 255 {
-		return false;
-	}
+    // validate the length of each part of the email, BEFORE doing the regex
+    // according to RFC5321 the max length of the local part is 64 characters
+    // and the max length of the domain part is 255 characters
+    // https://datatracker.ietf.org/doc/html/rfc5321#section-4.5.3.1.1
+    if user_part.length() > 64 || domain_part.length() > 255 {
+        return false;
+    }
 
     if !EMAIL_USER_RE.is_match(user_part) {
         return false;
@@ -59,11 +59,7 @@ where
 /// Checks if the domain is a valid domain and if not, check whether it's an IP
 #[must_use]
 fn validate_domain_part(domain_part: &str) -> bool {
-    if domain_part.length() > 255 {
-		return false;
-	}
-	
-	if EMAIL_DOMAIN_RE.is_match(domain_part) {
+    if EMAIL_DOMAIN_RE.is_match(domain_part) {
         return true;
     }
 
@@ -161,13 +157,13 @@ mod tests {
         assert_eq!(validate_email(test), false);
     }
 
-	#[test]
-	fn test_validate_email_rfc5321() {
-		// 65 character local part
-		let test = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa@mail.com";
-		assert_eq!(validate_email(test), false);
-		// 256 character domain part
-		let test = "a@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.com";
-		assert_eq!(validate_email(test), false);
-	}
+    #[test]
+    fn test_validate_email_rfc5321() {
+        // 65 character local part
+        let test = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa@mail.com";
+        assert_eq!(validate_email(test), false);
+        // 256 character domain part
+        let test = "a@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.com";
+        assert_eq!(validate_email(test), false);
+    }
 }

--- a/validator/src/validation/email.rs
+++ b/validator/src/validation/email.rs
@@ -3,7 +3,7 @@ use lazy_static::lazy_static;
 use regex::Regex;
 use std::borrow::Cow;
 
-use crate::validation::ip::validate_ip;
+use crate::{validation::ip::validate_ip, HasLen};
 
 lazy_static! {
     // Regex from the specs
@@ -33,6 +33,14 @@ where
     let user_part = parts[1];
     let domain_part = parts[0];
 
+	// validate the length of each part of the email, BEFORE doing the regex
+	// according to RFC5321 the max length of the local part is 64 characters
+	// and the max length of the domain part is 255 characters
+	// https://datatracker.ietf.org/doc/html/rfc5321#section-4.5.3.1.1
+	if user_part.length() > 64 || domain_part.length() > 255 {
+		return false;
+	}
+
     if !EMAIL_USER_RE.is_match(user_part) {
         return false;
     }
@@ -51,7 +59,11 @@ where
 /// Checks if the domain is a valid domain and if not, check whether it's an IP
 #[must_use]
 fn validate_domain_part(domain_part: &str) -> bool {
-    if EMAIL_DOMAIN_RE.is_match(domain_part) {
+    if domain_part.length() > 255 {
+		return false;
+	}
+	
+	if EMAIL_DOMAIN_RE.is_match(domain_part) {
         return true;
     }
 
@@ -148,4 +160,14 @@ mod tests {
         let test: Cow<'static, str> = String::from("a@[127.0.0.1]\n").into();
         assert_eq!(validate_email(test), false);
     }
+
+	#[test]
+	fn test_validate_email_rfc5321() {
+		// 65 character local part
+		let test = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa@mail.com";
+		assert_eq!(validate_email(test), false);
+		// 256 character domain part
+		let test = "a@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.com";
+		assert_eq!(validate_email(test), false);
+	}
 }


### PR DESCRIPTION
I added validation for emails before doing regex validation on the input. However these RFC standards are a bit confusing and I'm unsure what lengths to set each part of the address to.

The regex, I think, validates the lengths like [??].[??]@[63].[63] 

Is the length of the user part being validated?

Fixes #209 