### PR TITLE
Add readme to Cargo.toml

### DIFF
--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -8,6 +8,7 @@ homepage = "https://github.com/Keats/validator"
 repository = "https://github.com/Keats/validator"
 keywords = ["validation", "api", "validator"]
 edition = "2018"
+readme = "../README.md"
 
 [dependencies]
 url = "2"

--- a/validator_derive/Cargo.toml
+++ b/validator_derive/Cargo.toml
@@ -8,6 +8,7 @@ homepage = "https://github.com/Keats/validator"
 repository = "https://github.com/Keats/validator"
 keywords = ["validation", "api", "validator"]
 edition = "2018"
+readme = "../README.md"
 
 [lib]
 proc-macro = true

--- a/validator_types/Cargo.toml
+++ b/validator_types/Cargo.toml
@@ -8,6 +8,7 @@ homepage = "https://github.com/Keats/validator"
 repository = "https://github.com/Keats/validator"
 keywords = ["validation", "api", "validator"]
 edition = "2018"
+readme = "../README.md"
 
 
 [features]


### PR DESCRIPTION
This will add the Readme file to the sources uploaded to crates.io. 
In return this makes packaging easier for distributions ( i am currently packaging this crate for fedora)