### PR TITLE
allow single_use_lifetimes lint

### DIFF
--- a/validator_derive/src/lib.rs
+++ b/validator_derive/src/lib.rs
@@ -72,6 +72,9 @@ fn impl_validate(ast: &syn::DeriveInput) -> proc_macro2::TokenStream {
         // We need this here to prevent formatting lints that can be caused by `quote_spanned!`
         // See: rust-lang/rust-clippy#6249 for more reference
         #[allow(clippy::all)]
+        // Triggers when single_use_lifetimes rustc lint is configured in user project and there are no
+        // usages of 'v_a lifetime in the generated impl definition
+        #[allow(single_use_lifetimes)]
         impl #impl_generics ::validator::ValidateArgs<'v_a> for #ident #ty_generics #where_clause {
             type Args = #arg_type;
 


### PR DESCRIPTION
I set warn level for `single_use_lifetimes` rustc lint in my project.

This lint triggers for structs that don't have references and derive `Validate` trait.

The fix allows to have single use of the `'v_a` lifetime.