### PR TITLE
feat: add nested support for slices and most list/iterable types

### DIFF
--- a/validator/src/traits.rs
+++ b/validator/src/traits.rs
@@ -50,6 +50,24 @@ impl<'a, T> HasLen for &'a Vec<T> {
     }
 }
 
+impl<T> HasLen for &[T] {
+    fn length(&self) -> u64 {
+        self.len() as u64
+    }
+}
+
+impl<T, const N: usize> HasLen for [T; N] {
+    fn length(&self) -> u64 {
+        N as u64
+    }
+}
+
+impl<T, const N: usize> HasLen for &[T; N] {
+    fn length(&self) -> u64 {
+        N as u64
+    }
+}
+
 impl<'a, K, V, S> HasLen for &'a HashMap<K, V, S> {
     fn length(&self) -> u64 {
         self.len() as u64

--- a/validator_derive/src/asserts.rs
+++ b/validator_derive/src/asserts.rs
@@ -8,7 +8,7 @@ use syn::spanned::Spanned;
 lazy_static! {
     pub static ref COW_TYPE: Regex = Regex::new(r"Cow<'[a-z]+,str>").unwrap();
     pub static ref LEN_TYPE: Regex =
-        Regex::new(r"(Option<)?(Vec|HashMap|HashSet|BTreeMap|BTreeSet|IndexMap|IndexSet)<")
+        Regex::new(r"(Option<)?((Vec|HashMap|HashSet|BTreeMap|BTreeSet|IndexMap|IndexSet)<|\[)")
             .unwrap();
 }
 
@@ -97,14 +97,14 @@ pub fn assert_has_len(field_name: String, type_name: &str, field_type: &syn::Typ
         return;
     }
 
-    if !type_name.contains("String") 
+    if !type_name.contains("String")
         && !type_name.contains("str")
         && !LEN_TYPE.is_match(type_name)
         // a bit ugly
         && !COW_TYPE.is_match(type_name)
     {
         abort!(field_type.span(),
-                "Validator `length` can only be used on types `String`, `&str`, Cow<'_,str>, `Vec`, or map/set types (BTree/Hash/Index) but found `{}` for field `{}`",
+                "Validator `length` can only be used on types `String`, `&str`, Cow<'_,str>, `Vec`, slice, or map/set types (BTree/Hash/Index) but found `{}` for field `{}`",
                 type_name, field_name
             );
     }

--- a/validator_derive/src/lib.rs
+++ b/validator_derive/src/lib.rs
@@ -72,6 +72,9 @@ fn impl_validate(ast: &syn::DeriveInput) -> proc_macro2::TokenStream {
         // We need this here to prevent formatting lints that can be caused by `quote_spanned!`
         // See: rust-lang/rust-clippy#6249 for more reference
         #[allow(clippy::all)]
+        // Triggers when single_use_lifetimes rustc lint is configured in user project and there are no
+        // usages of 'v_a lifetime in the generated impl definition
+        #[allow(single_use_lifetimes)]
         impl #impl_generics ::validator::ValidateArgs<'v_a> for #ident #ty_generics #where_clause {
             type Args = #arg_type;
 

--- a/validator_derive_tests/tests/compile-fail/length/wrong_type.stderr
+++ b/validator_derive_tests/tests/compile-fail/length/wrong_type.stderr
@@ -1,4 +1,4 @@
-error: Validator `length` can only be used on types `String`, `&str`, Cow<'_,str>, `Vec`, or map/set types (BTree/Hash/Index) but found `usize` for field `s`
+error: Validator `length` can only be used on types `String`, `&str`, Cow<'_,str>, `Vec`, slice, or map/set types (BTree/Hash/Index) but found `usize` for field `s`
  --> $DIR/wrong_type.rs:6:8
   |
 6 |     s: usize,

--- a/validator_derive_tests/tests/length.rs
+++ b/validator_derive_tests/tests/length.rs
@@ -150,6 +150,53 @@ fn can_validate_ref_for_length() {
     assert_eq!(errs["val"][0].params["max"], 10);
 }
 
+#[test]
+fn can_validate_slice_for_length() {
+    use serde_json::Value;
+
+    #[derive(Debug, Validate)]
+    struct TestStruct<'a> {
+        #[validate(length(min = 5, max = 10))]
+        val: &'a [String],
+    }
+
+    let strings = vec![String::new()];
+    let s = TestStruct { val: &strings };
+    let res = s.validate();
+    assert!(res.is_err());
+    let err = res.unwrap_err();
+    let errs = err.field_errors();
+    assert!(errs.contains_key("val"));
+    assert_eq!(errs["val"].len(), 1);
+    assert_eq!(errs["val"][0].code, "length");
+    assert_eq!(errs["val"][0].params["value"], Value::Array(vec![Value::String(String::new())]));
+    assert_eq!(errs["val"][0].params["min"], 5);
+    assert_eq!(errs["val"][0].params["max"], 10);
+}
+
+#[test]
+fn can_validate_array_for_length() {
+    use serde_json::Value;
+
+    #[derive(Debug, Validate)]
+    struct TestStruct {
+        #[validate(length(min = 5, max = 10))]
+        val: [String; 1],
+    }
+
+    let s = TestStruct { val: [String::new()] };
+    let res = s.validate();
+    assert!(res.is_err());
+    let err = res.unwrap_err();
+    let errs = err.field_errors();
+    assert!(errs.contains_key("val"));
+    assert_eq!(errs["val"].len(), 1);
+    assert_eq!(errs["val"][0].code, "length");
+    assert_eq!(errs["val"][0].params["value"], Value::Array(vec![Value::String(String::new())]));
+    assert_eq!(errs["val"][0].params["min"], 5);
+    assert_eq!(errs["val"][0].params["max"], 10);
+}
+
 #[cfg(feature = "indexmap")]
 #[test]
 fn can_validate_set_ref_for_length() {


### PR DESCRIPTION
This now support nested validation for the following types:
- `[T; N]`
- `&[T]`
- `Option<[T; N]>`
- `&HashMap`, `&BTreeMap`, `&FxHashMap`, `&FnvHashMap`
- `HashSet` and `&HashSet`
- `BTreeSet` and `&BTreeSet`
- `IndexMap` and `&IndexMap`
- `IndexSet` and `&IndexSet`

Sadly, I was not able to get `Option<&T>` working properly because of lifetimes and how `_type` is generated inside of `FieldQuoter`: the space disappears between the lifetime and the inner type, making it impossible to extract the real type. (e.g. `Option<&'a HashSet<Child>>` becomes `Option<&'aHashSet<Child>>`, leading to the inner type `aHashSet`)