### PR TITLE
Add additional badges to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,25 @@
 # validator
 
-![Build](https://github.com/Keats/validator/workflows/ci/badge.svg)
+<div align="center">
+  <!-- Github Actions -->
+  <img src="https://github.com/Keats/validator/workflows/ci/badge.svg" alt="actions status" />
+  <!-- Version -->
+  <a href="https://crates.io/crates/validator">
+    <img src="https://img.shields.io/crates/v/validator.svg?style=flat-square"
+    alt="Crates.io version" />
+  </a>
+  <!-- Docs -->
+  <a href="https://docs.rs/validator">
+    <img src="https://img.shields.io/badge/docs-latest-blue.svg?style=flat-square"
+      alt="docs.rs docs" />
+  </a>
+  <!-- Downloads -->
+  <a href="https://crates.io/crates/validator">
+    <img src="https://img.shields.io/crates/d/validator.svg?style=flat-square"
+      alt="Download" />
+  </a>
+</div>
+
 
 Macros 1.1 custom derive to simplify struct validation inspired by [marshmallow](http://marshmallow.readthedocs.io/en/latest/) and
 [Django validators](https://docs.djangoproject.com/en/1.10/ref/validators/).


### PR DESCRIPTION
This change adds additional badges to the README.md file for quicker navigation between crates.io / github / docs.rs.

The structure is shamelessly copied from SQLx (that was the first repo I thought of to check).