### PR TITLE
Improve Display Impl - Each ValidatorError should be on its own line

### DIFF
--- a/validator/src/display_impl.rs
+++ b/validator/src/display_impl.rs
@@ -5,9 +5,9 @@ use crate::{ValidationError, ValidationErrors, ValidationErrorsKind};
 impl fmt::Display for ValidationError {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let Some(msg) = self.message.as_ref() {
-            write!(fmt, "{}", msg)
+            writeln!(fmt, "{}", msg)
         } else {
-            write!(fmt, "Validation error: {} [{:?}]", self.code, self.params)
+            writeln!(fmt, "Validation error: {} [{:?}]", self.code, self.params)
         }
     }
 }

--- a/validator/tests/display.rs
+++ b/validator/tests/display.rs
@@ -47,9 +47,13 @@ mod tests {
 
     #[test]
     fn test_nested_vec() {
-        let bad_foo = Foo { foo: "hi!".into() };
-        let bad_baz = Baz { baz: vec![bad_foo] };
+        let bad_foo_1 = Foo { foo: "hi!".into() };
+        let bad_foo_2 = Foo { foo: "hi!".into() };
+        let bad_baz = Baz { baz: vec![bad_foo_1, bad_foo_2] };
         let err = format!("{}", bad_baz.validate().unwrap_err());
-        assert_eq!(err, "baz[0].foo: Please provide a valid foo!");
+        assert_eq!(
+            err,
+            "baz[0].foo: Please provide a valid foo!\nbaz[1].foo: Please provide a valid foo!"
+        );
     }
 }


### PR DESCRIPTION
The current impl for Display doesn't break newlines frequently enough.

The display output of the list variant of `ValidationErrorsKind` currently looks like the following:
```
my_field[0].subfield: Validation error: Some error. [{"value": String("some-value")}]my_field[1].subfield: Validation error: Some error. [{"value": String("some-value-2")}]
other_field[0].other: Validation error: Other error [{"value": String("other-value")}]
```
It only breaks line when the top-level field of the `ValidationErrors` changes. I would prefer for it to look like the following:

```
my_field[0].subfield: Validation error: Some error. [{"value": String("some-value")}]
my_field[1].subfield: Validation error: Some error. [{"value": String("some-value-2")}]

other_field[0].other: Validation error: Other error [{"value": String("other-value")}]
```
It seems pretty clear that separate field-level errors belong on their own line - having multiple on the same line always looks bad. Having multiple line-breaks when the top-level field changes doesn't feel like a regression either, but we could remove the existing `writeln!` call if we wanted a maximum of 1 new line after every error display.