### PR TITLE
add length_utf16 validator

### DIFF
--- a/validator/src/lib.rs
+++ b/validator/src/lib.rs
@@ -76,6 +76,7 @@ pub use validation::does_not_contain::validate_does_not_contain;
 pub use validation::email::validate_email;
 pub use validation::ip::{validate_ip, validate_ip_v4, validate_ip_v6};
 pub use validation::length::validate_length;
+pub use validation::length_utf16::validate_length_utf16;
 pub use validation::must_match::validate_must_match;
 #[cfg(feature = "unic")]
 pub use validation::non_control_character::validate_non_control_character;

--- a/validator/src/traits.rs
+++ b/validator/src/traits.rs
@@ -144,6 +144,36 @@ impl<T> HasLen for IndexSet<T> {
     }
 }
 
+/// Allows to limit string length in UTF-16 characters
+///
+/// UTF-16 is used in JavaScript and Java.
+pub trait HasLenUTF16 {
+    fn length_utf16(&self) -> u64;
+}
+
+impl HasLenUTF16 for String {
+    fn length_utf16(&self) -> u64 {
+        self.encode_utf16().count() as u64
+    }
+}
+
+impl<'a> HasLenUTF16 for &'a String {
+    fn length_utf16(&self) -> u64 {
+        self.encode_utf16().count() as u64
+    }
+}
+
+impl<'a> HasLenUTF16 for &'a str {
+    fn length_utf16(&self) -> u64 {
+        self.encode_utf16().count() as u64
+    }
+}
+
+impl<'a> HasLenUTF16 for Cow<'a, str> {
+    fn length_utf16(&self) -> u64 {
+        self.encode_utf16().count() as u64
+    }
+}
 /// Trait to implement if one wants to make the `contains` validator
 /// work for more types
 pub trait Contains {

--- a/validator/src/validation/length_utf16.rs
+++ b/validator/src/validation/length_utf16.rs
@@ -1,0 +1,74 @@
+use crate::traits::HasLenUTF16;
+
+/// Validates the length of the value given.
+/// If the validator has `equal` set, it will ignore any `min` and `max` value.
+///
+/// If you apply it on String, don't forget that the length can be different
+/// from the number of visual characters for Unicode
+#[must_use]
+pub fn validate_length_utf16<T: HasLenUTF16>(
+    value: T,
+    min: Option<u64>,
+    max: Option<u64>,
+    equal: Option<u64>,
+) -> bool {
+    let val_length = value.length_utf16();
+
+    if let Some(eq) = equal {
+        return val_length == eq;
+    } else {
+        if let Some(m) = min {
+            if val_length < m {
+                return false;
+            }
+        }
+        if let Some(m) = max {
+            if val_length > m {
+                return false;
+            }
+        }
+    }
+
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use std::borrow::Cow;
+
+    use super::validate_length_utf16;
+
+    #[test]
+    fn test_validate_length_equal_overrides_min_max() {
+        assert!(validate_length_utf16("hello", Some(1), Some(2), Some(5)));
+    }
+
+    #[test]
+    fn test_validate_length_string_min_max() {
+        assert!(validate_length_utf16("hello", Some(1), Some(10), None));
+    }
+
+    #[test]
+    fn test_validate_length_string_min_only() {
+        assert!(!validate_length_utf16("hello", Some(10), None, None));
+    }
+
+    #[test]
+    fn test_validate_length_string_max_only() {
+        assert!(!validate_length_utf16("hello", None, Some(1), None));
+    }
+
+    #[test]
+    fn test_validate_length_cow() {
+        let test: Cow<'static, str> = "hello".into();
+        assert!(validate_length_utf16(test, None, None, Some(5)));
+
+        let test: Cow<'static, str> = String::from("hello").into();
+        assert!(validate_length_utf16(test, None, None, Some(5)));
+    }
+
+    #[test]
+    fn test_validate_length_unicode_chars() {
+        assert!(validate_length_utf16("𝔠", None, None, Some(2)));
+    }
+}

--- a/validator/src/validation/mod.rs
+++ b/validator/src/validation/mod.rs
@@ -5,6 +5,7 @@ pub mod does_not_contain;
 pub mod email;
 pub mod ip;
 pub mod length;
+pub mod length_utf16;
 pub mod must_match;
 #[cfg(feature = "unic")]
 pub mod non_control_character;

--- a/validator/tests/display.rs
+++ b/validator/tests/display.rs
@@ -15,6 +15,19 @@ mod tests {
         assert_eq!(err, "foo: Please provide a valid foo!");
     }
 
+    #[derive(Validate, Clone)]
+    struct FooUTF16 {
+        #[validate(length_utf16(equal = 5, message = "Please provide a valid utf16 foo!"))]
+        foo: String,
+    }
+
+    #[test]
+    fn test_message() {
+        let bad_foo = FooUTF16 { foo: "hi!".into() };
+        let err = format!("{}", bad_foo.validate().unwrap_err());
+        assert_eq!(err, "foo: Please provide a valid utf16 foo!");
+    }
+
     #[derive(Validate)]
     struct Bar {
         #[validate]

--- a/validator_derive/src/lib.rs
+++ b/validator_derive/src/lib.rs
@@ -9,7 +9,9 @@ use quote::ToTokens;
 use quote::{quote, quote_spanned};
 use syn::{parse_quote, spanned::Spanned, GenericParam, Lifetime, LifetimeDef, Type};
 
-use asserts::{assert_has_len, assert_has_range, assert_string_type, assert_type_matches};
+use asserts::{
+    assert_has_len, assert_has_len_utf16, assert_has_range, assert_string_type, assert_type_matches,
+};
 use lit::*;
 use quoting::{quote_schema_validations, quote_validator, FieldQuoter};
 use validation::*;
@@ -508,6 +510,18 @@ fn find_validators_for_field(
                                     "length" => {
                                         assert_has_len(rust_ident.clone(), field_type, &field.ty);
                                         validators.push(extract_length_validation(
+                                            rust_ident.clone(),
+                                            attr,
+                                            &meta_items,
+                                        ));
+                                    }
+                                    "length_utf16" => {
+                                        assert_has_len_utf16(
+                                            rust_ident.clone(),
+                                            field_type,
+                                            &field.ty,
+                                        );
+                                        validators.push(extract_length_utf16_validation(
                                             rust_ident.clone(),
                                             attr,
                                             &meta_items,

--- a/validator_derive_tests/tests/length_utf16.rs
+++ b/validator_derive_tests/tests/length_utf16.rs
@@ -1,0 +1,127 @@
+use validator::Validate;
+
+const MIN_CONST: u64 = 1;
+const MAX_CONST: u64 = 10;
+
+const MAX_CONST_I32: i32 = 2;
+const NEGATIVE_CONST_I32: i32 = -10;
+
+#[test]
+fn can_validate_length_utf16_ok() {
+    #[derive(Debug, Validate)]
+    struct TestStruct {
+        #[validate(length_utf16(min = 5, max = 10))]
+        val: String,
+    }
+
+    let s = TestStruct { val: "hello".to_string() };
+
+    assert!(s.validate().is_ok());
+}
+
+#[test]
+fn validate_length_utf16_with_ref_ok() {
+    #[derive(Debug, Validate)]
+    struct TestStruct {
+        #[validate(length_utf16(min = "MIN_CONST", max = "MAX_CONST"))]
+        val: String,
+    }
+
+    let s = TestStruct { val: "hello".to_string() };
+
+    assert!(s.validate().is_ok());
+}
+
+#[test]
+fn validate_length_utf16_with_ref_fails() {
+    #[derive(Debug, Validate)]
+    struct TestStruct {
+        #[validate(length_utf16(min = "MIN_CONST", max = "MAX_CONST"))]
+        val: String,
+    }
+
+    let s = TestStruct { val: "".to_string() };
+
+    assert!(s.validate().is_err());
+}
+
+#[test]
+fn validate_length_utf16_with_ref_i32_fails() {
+    #[derive(Debug, Validate)]
+    struct TestStruct {
+        #[validate(length_utf16(max = "MAX_CONST_I32"))]
+        val: String,
+    }
+
+    let s = TestStruct { val: "TO_LONG_YAY".to_string() };
+
+    assert!(s.validate().is_err());
+}
+
+#[test]
+fn validate_length_utf16_with_ref_negative_i32_fails() {
+    #[derive(Debug, Validate)]
+    struct TestStruct {
+        #[validate(length_utf16(max = "NEGATIVE_CONST_I32"))]
+        val: String,
+    }
+
+    let s = TestStruct { val: "TO_LONG_YAY".to_string() };
+
+    assert!(s.validate().is_ok());
+}
+
+#[test]
+fn value_out_of_length_utf16_fails_validation() {
+    #[derive(Debug, Validate)]
+    struct TestStruct {
+        #[validate(length_utf16(min = 5, max = 10))]
+        val: String,
+    }
+
+    let s = TestStruct { val: String::new() };
+    let res = s.validate();
+    assert!(res.is_err());
+    let err = res.unwrap_err();
+    let errs = err.field_errors();
+    assert!(errs.contains_key("val"));
+    assert_eq!(errs["val"].len(), 1);
+    assert_eq!(errs["val"][0].code, "length_utf16");
+    assert_eq!(errs["val"][0].params["value"], "");
+    assert_eq!(errs["val"][0].params["min"], 5);
+    assert_eq!(errs["val"][0].params["max"], 10);
+}
+
+#[test]
+fn can_specify_code_for_length_utf16() {
+    #[derive(Debug, Validate)]
+    struct TestStruct {
+        #[validate(length_utf16(min = 5, max = 10, code = "oops"))]
+        val: String,
+    }
+    let s = TestStruct { val: String::new() };
+    let res = s.validate();
+    assert!(res.is_err());
+    let err = res.unwrap_err();
+    let errs = err.field_errors();
+    assert!(errs.contains_key("val"));
+    assert_eq!(errs["val"].len(), 1);
+    assert_eq!(errs["val"][0].code, "oops");
+}
+
+#[test]
+fn can_specify_message_for_length_utf16() {
+    #[derive(Debug, Validate)]
+    struct TestStruct {
+        #[validate(length_utf16(min = 5, max = 10, message = "oops"))]
+        val: String,
+    }
+    let s = TestStruct { val: String::new() };
+    let res = s.validate();
+    assert!(res.is_err());
+    let err = res.unwrap_err();
+    let errs = err.field_errors();
+    assert!(errs.contains_key("val"));
+    assert_eq!(errs["val"].len(), 1);
+    assert_eq!(errs["val"][0].clone().message.unwrap(), "oops");
+}

--- a/validator_types/src/lib.rs
+++ b/validator_types/src/lib.rs
@@ -31,6 +31,12 @@ pub enum Validator {
         max: Option<ValueOrPath<u64>>,
         equal: Option<ValueOrPath<u64>>,
     },
+    // string value validated against length in UTF-16 characters (string repr in JavaScript, Java)
+    LengthUTF16 {
+        min: Option<ValueOrPath<u64>>,
+        max: Option<ValueOrPath<u64>>,
+        equal: Option<ValueOrPath<u64>>,
+    },
     #[cfg(feature = "card")]
     CreditCard,
     #[cfg(feature = "phone")]
@@ -81,6 +87,7 @@ impl Validator {
             Validator::Regex(_) => "regex",
             Validator::Range { .. } => "range",
             Validator::Length { .. } => "length",
+            Validator::LengthUTF16 { .. } => "length_utf16",
             #[cfg(feature = "card")]
             Validator::CreditCard => "credit_card",
             #[cfg(feature = "phone")]


### PR DESCRIPTION
This PR adds length_utf16 validator.

My project exposes data from Salesforce via JsonSchema based API. I want to validate field lengths in the same way as Salesforce does - by counting UTF16 characters.

UTF16 is used for Unicode string representation in JavaScript, Java and Salesforce APEX. I think this validator could be useful to others as well.

Should I wrap the implementation in optional feature `length_utf16` ?