### PR TITLE
Fully remove code for old phone validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,6 @@ use validator::{Validate, ValidationError};
 struct SignupData {
     #[validate(email)]
     mail: String,
-    #[validate(phone)]
-    phone: String,
     #[validate(url)]
     site: String,
     #[validate(length(min = 1), custom = "validate_unique_username")]
@@ -127,8 +125,6 @@ struct SignupData {
 struct ContactDetails {
     #[validate(email)]
     mail: String,
-    #[validate(phone)]
-    phone: String
 }
 
 #[derive(Debug, Validate, Deserialize)]
@@ -275,13 +271,6 @@ Examples:
 ```rust
 #[validate(credit_card)]
 ```
-
-### phone
-Tests whether the String is a valid phone number (in international format, ie.
-containing the country indicator like `+14152370800` for an US number — where `4152370800`
-is the national number equivalent, which is seen as invalid).
-To use this validator, you must enable the `phone` feature for the `validator` crate.
-This validator doesn't take any arguments: `#[validate(phone)]`;
 
 ### custom
 Calls one of your functions to perform a custom validation. The field reference will be given as a parameter to the function,

--- a/validator/src/lib.rs
+++ b/validator/src/lib.rs
@@ -10,8 +10,6 @@
 //! struct SignupData {
 //!     #[validate(email)]
 //!     mail: String,
-//!     #[validate(phone)]
-//!     phone: String,
 //!     #[validate(url)]
 //!     site: String,
 //!     #[validate(length(min = 1), custom = "validate_unique_username")]
@@ -49,7 +47,6 @@
 //! | `custom`                |                                                       |
 //! | `regex`                 |                                                       |
 //! | `credit_card`           | (Requires the feature `card` to be enabled)           |
-//! | `phone`                 | (Requires the feature `phone` to be enabled)          |
 //! | `non_control_character` | (Required the feature `unic` to be enabled)           |
 //! | `nested`                | (Uses the validation of the field type it self)       |
 //! | `required`              |                                                       |
@@ -79,8 +76,6 @@ pub use validation::length::{validate_length, ValidateLength};
 pub use validation::must_match::validate_must_match;
 #[cfg(feature = "unic")]
 pub use validation::non_control_character::validate_non_control_character;
-#[cfg(feature = "phone")]
-pub use validation::phone::validate_phone;
 pub use validation::range::{validate_range, ValidateRange};
 
 pub use validation::required::{validate_required, ValidateRequired};

--- a/validator_derive_tests/tests/compile-fail/custom/validate_not_impl_with_args.stderr
+++ b/validator_derive_tests/tests/compile-fail/custom/validate_not_impl_with_args.stderr
@@ -1,8 +1,8 @@
 error[E0599]: no method named `validate` found for struct `Test` in the current scope
-  --> $DIR/validate_not_impl_with_args.rs:15:10
+  --> tests/compile-fail/custom/validate_not_impl_with_args.rs:15:10
    |
 8  | struct Test {
-   | ----------- method `validate` not found for this
+   | ----------- method `validate` not found for this struct
 ...
 15 |     test.validate();
    |          ^^^^^^^^ method not found in `Test`

--- a/validator_derive_tests/tests/compile-fail/no_nested_validations.stderr
+++ b/validator_derive_tests/tests/compile-fail/no_nested_validations.stderr
@@ -5,7 +5,7 @@ error[E0599]: no method named `validate` found for struct `Nested` in the curren
   |          ^^^^^^^^ method not found in `Nested`
 ...
 9 | struct Nested {
-  | ------------- method `validate` not found for this
+  | ------------- method `validate` not found for this struct
   |
   = help: items from traits can only be used if the trait is implemented and in scope
   = note: the following trait defines an item `validate`, perhaps you need to implement it:

--- a/validator_derive_tests/tests/complex.rs
+++ b/validator_derive_tests/tests/complex.rs
@@ -35,17 +35,9 @@ struct SignupData {
     #[validate(range(min = 18, max = 20))]
     age: u32,
     #[validate]
-    phone: Phone,
-    #[validate]
     card: Option<Card>,
     #[validate]
     preferences: Vec<Preference>,
-}
-
-#[derive(Debug, Validate, Deserialize)]
-struct Phone {
-    #[validate(phone)]
-    number: String,
 }
 
 #[derive(Debug, Validate, Deserialize)]
@@ -71,7 +63,6 @@ fn is_fine_with_many_valid_validations() {
         site: "http://hello.com".to_string(),
         first_name: "Bob".to_string(),
         age: 18,
-        phone: Phone { number: "+14152370800".to_string() },
         card: Some(Card { number: "5236313877109142".to_string(), cvv: 123 }),
         preferences: vec![Preference { name: "marketing".to_string(), value: false }],
     };
@@ -86,7 +77,6 @@ fn failed_validation_points_to_original_field_name() {
         site: "http://hello.com".to_string(),
         first_name: "".to_string(),
         age: 18,
-        phone: Phone { number: "123 invalid".to_string() },
         card: Some(Card { number: "1234567890123456".to_string(), cvv: 1 }),
         preferences: vec![Preference { name: "abc".to_string(), value: true }],
     };
@@ -101,21 +91,6 @@ fn failed_validation_points_to_original_field_name() {
         assert_eq!(err[0].code, "length");
     } else {
         panic!("Expected field validation errors");
-    }
-    assert!(errs.contains_key("phone"));
-    if let ValidationErrorsKind::Struct(ref errs) = errs["phone"] {
-        unwrap_map(errs, |errs| {
-            assert_eq!(errs.len(), 1);
-            assert!(errs.contains_key("number"));
-            if let ValidationErrorsKind::Field(ref errs) = errs["number"] {
-                assert_eq!(errs.len(), 1);
-                assert_eq!(errs[0].code, "phone");
-            } else {
-                panic!("Expected field validation errors");
-            }
-        });
-    } else {
-        panic!("Expected struct validation errors");
     }
     assert!(errs.contains_key("card"));
     if let ValidationErrorsKind::Struct(ref errs) = errs["card"] {
@@ -261,7 +236,6 @@ fn test_works_with_question_mark_operator() {
             site: "http://hello.com".to_string(),
             first_name: "Bob".to_string(),
             age: 18,
-            phone: Phone { number: "+14152370800".to_string() },
             card: None,
             preferences: Vec::new(),
         };

--- a/validator_derive_tests/tests/run-pass/phone.rs
+++ b/validator_derive_tests/tests/run-pass/phone.rs
@@ -1,9 +1,0 @@
-use validator::Validate;
-
-#[derive(Validate)]
-struct Test {
-    #[validate(phone)]
-    s: String,
-}
-
-fn main() {}

--- a/validator_types/src/lib.rs
+++ b/validator_types/src/lib.rs
@@ -35,8 +35,6 @@ pub enum Validator {
     },
     #[cfg(feature = "card")]
     CreditCard,
-    #[cfg(feature = "phone")]
-    Phone,
     Nested,
     #[cfg(feature = "unic")]
     NonControlCharacter,
@@ -85,8 +83,6 @@ impl Validator {
             Validator::Length { .. } => "length",
             #[cfg(feature = "card")]
             Validator::CreditCard => "credit_card",
-            #[cfg(feature = "phone")]
-            Validator::Phone => "phone",
             Validator::Nested => "nested",
             #[cfg(feature = "unic")]
             Validator::NonControlCharacter => "non_control_character",


### PR DESCRIPTION
The phone validation code was partially removed in 897811a but parts were left in leading to tests not passing.

This also updates the expected compiler errors for two compile-fail cases.  There is one that is still failing, but I haven't had the time to look into it yet.