### PR TITLE
Delete old not_a_string_type test

### DIFF
--- a/validator_derive_tests/tests/compile-fail/not_a_string_type.rs
+++ b/validator_derive_tests/tests/compile-fail/not_a_string_type.rs
@@ -1,9 +1,0 @@
-use validator::Validate;
-
-#[derive(Validate)]
-struct Register {
-    #[validate(email)]
-    email: Vec<u8>,
-}
-
-fn main() {}

--- a/validator_derive_tests/tests/compile-fail/not_a_string_type.stderr
+++ b/validator_derive_tests/tests/compile-fail/not_a_string_type.stderr
@@ -1,5 +1,0 @@
-error: `email` validator can only be used on String, &str, Cow<'_,str> or an Option of those
- --> $DIR/not_a_string_type.rs:6:12
-  |
-6 |     email: Vec<u8>,
-  |            ^^^


### PR DESCRIPTION
This test was checking that the derive macro assertion about the type not being one of the known string types was working, but now since we allow implementations of the email validation for third-party types there is no way for us to perform this check in the derive macro.

The same assertion is still used for the credit card and non-control character validators, but those will also soon be switched to be trait-based.