### PR TITLE
Disable unnecessary/unused regex features

### DIFF
--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -12,7 +12,7 @@ readme = "../README.md"
 
 [dependencies]
 url = "2"
-regex = "1"
+regex = { version = "1", default-features = false, features = ["std"] }
 lazy_static = "1"
 idna = "0.2"
 serde = "1"

--- a/validator/src/validation/email.rs
+++ b/validator/src/validation/email.rs
@@ -9,12 +9,12 @@ lazy_static! {
     // Regex from the specs
     // https://html.spec.whatwg.org/multipage/forms.html#valid-e-mail-address
     // It will mark esoteric email addresses like quoted string as invalid
-    static ref EMAIL_USER_RE: Regex = Regex::new(r"^(?i)[a-z0-9.!#$%&'*+/=?^_`{|}~-]+\z").unwrap();
+    static ref EMAIL_USER_RE: Regex = Regex::new(r"^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+\z").unwrap();
     static ref EMAIL_DOMAIN_RE: Regex = Regex::new(
-        r"(?i)^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)*$"
+        r"^[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$"
     ).unwrap();
     // literal form, ipv4 or ipv6 address (SMTP 4.1.3)
-    static ref EMAIL_LITERAL_RE: Regex = Regex::new(r"(?i)\[([A-f0-9:\.]+)\]\z").unwrap();
+    static ref EMAIL_LITERAL_RE: Regex = Regex::new(r"\[([a-fA-F0-9:\.]+)\]\z").unwrap();
 }
 
 /// Validates whether the given string is an email based on the [HTML5 spec](https://html.spec.whatwg.org/multipage/forms.html#valid-e-mail-address).

--- a/validator_derive/Cargo.toml
+++ b/validator_derive/Cargo.toml
@@ -24,7 +24,7 @@ proc-macro2 = "1"
 proc-macro-error = "1"
 if_chain = "1"
 validator_types = { version = "0.16", path = "../validator_types" }
-regex = "1.5.5"
+regex = { version = "1.5.5", default-features = false, features = ["std"] }
 lazy_static = "1"
 
 


### PR DESCRIPTION
### Avoid unnecessary case-insensitive regexes

The case-insensitive flag `(?i)` requires regex with the unicode-case
feature enabled which significantly increases the binary size and makes
regex slower.

### Disable unnecessary/unused regex features

regex crate with default features enabled is huge, it significantly
increases the binary size and compile time.

Cargo features are additive, so once some feature is enabled anywhere in
the dependency graph, there's no way to disable it, i.e. one
(transitive) dependency infects the whole dependency graph.

Since `#[validate(regex = "...")]` takes a path to a static Regex
instance, not regex as a string, users have to add the `regex`
dependency to their Cargo.toml to use it. Therefore, this change
shouldn't break backward compatibility.