### PR TITLE
Add ValidateAll derive macro which automatically adds nested validation to all fields

### DIFF
--- a/validator/src/lib.rs
+++ b/validator/src/lib.rs
@@ -91,3 +91,5 @@ pub use types::{ValidationError, ValidationErrors, ValidationErrorsKind};
 
 #[cfg(feature = "derive")]
 pub use validator_derive::Validate;
+#[cfg(feature = "derive")]
+pub use validator_derive::ValidateAll;

--- a/validator_derive/src/lib.rs
+++ b/validator_derive/src/lib.rs
@@ -454,6 +454,9 @@ fn find_validators_for_field(
                                         validators.push(FieldValidation::new(Validator::Required));
                                         validators.push(FieldValidation::new(Validator::Nested));
                                     }
+                                    "always_valid" => {
+                                        validators.push(FieldValidation::new(Validator::AlwaysValid));
+                                    }
                                     _ => {
                                         let mut ident = proc_macro2::TokenStream::new();
                                         name.to_tokens(&mut ident);

--- a/validator_derive/src/quoting.rs
+++ b/validator_derive/src/quoting.rs
@@ -537,6 +537,7 @@ pub fn quote_validator(
         Validator::DoesNotContain(_) => {
             validations.push(quote_does_not_contain_validation(field_quoter, validation))
         }
+        Validator::AlwaysValid => { }
     }
 }
 

--- a/validator_types/src/lib.rs
+++ b/validator_types/src/lib.rs
@@ -41,6 +41,7 @@ pub enum Validator {
     Required,
     RequiredNested,
     DoesNotContain(String),
+    AlwaysValid
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -91,6 +92,7 @@ impl Validator {
             Validator::Required => "required",
             Validator::RequiredNested => "required_nested",
             Validator::DoesNotContain(_) => "does_not_contain",
+            Validator::AlwaysValid => "always_valid"
         }
     }
 


### PR DESCRIPTION
My suggestion here is to add a second derive macro `ValidateAll` which operates similarly to the original (and unmodified) `Validate` macro, except if any fields don't have any validation, they are assumed to have Nested validation (as if they had the attribute `#[validate]`.

The use case here is when you have a Struct with many fields, most of which are more nested Structs. Down a few layers you probably have a Struct with more typical validation, such as:

```
#[derive(Validate)]
struct Address {
    name: String,
    #[validate(range(max = 99))]
    house_number: u8
    street: String
    #[validate(phone)]
    phone_number: String
    suburb: String
}
```
but in the upper layers you have many fields, all of which need Nested validation, writing `#[validate]` on every 2nd line would be quite verbose. So instead of having this:
```
#[derive(Validate)]
struct Order {
    #[validate]
    customer_number: u16,
    #[validate]
    billing_address: Address,
    #[validate]
    postal_address: Address,
    #[validate(email)]
    email: String,
    backup_address: Address
    #[validate]
    item_type: Item,
    #[validate(range(min = 1))]
    item_quantity: u8,
    #[validate]
    payment_method: Payment,
    #[validate]
    referrer: MarketingSource
}
```
you can simply put:
```
#[derive(ValidateAll)]
struct Order {
    customer_number: CustomerId,
    billing_address: Address,
    postal_address: Address,
    #[validate(email)]
    email: String,
    backup_address: Address
    item_type: Item,
    #[validate(range(min = 1))]
    item_quantity: u8,
    payment_method: Payment,
    referrer: MarketingSource
}
```
However there is another, and much more important catch here. The first option is not just verbose but its also prone to missing a field, meaning you *think* you are validating the nested data but you actually aren't. If you look closely, you'll see I forgot the `#[validate]` attribute on `backup_address` in the first example, but its not obvious at all. Once I use ValidateAll instead, it not only does the nesting for me, but if any of the types don't implement Validate (for example `MarketingSource`) then I'll get a compiler error telling me I forgot something.

I can't help but think this will benefit many people in many scenarios, but also I'm not tied to the exact implementation. If you don't like the extra derive macro `ValidateAll` another idea I had was adding a struct level attribute like `#[validate(mandatory_on_all_fields)]` which makes the `Validate` derive macro do the same thing as above.

Also in this PR is a new field level attribute `#[validate(always_valid)]` for the odd time when you want to use `ValidateAll` but some fields genuinely don't need validation.