### PR TITLE
Use `chars().count()` instead of `len()` for `Cow<'a, str>`

### DIFF
--- a/validator/src/traits.rs
+++ b/validator/src/traits.rs
@@ -34,7 +34,7 @@ impl<'a> HasLen for &'a str {
 
 impl<'a> HasLen for Cow<'a, str> {
     fn length(&self) -> u64 {
-        self.len() as u64
+        self.chars().count() as u64
     }
 }
 

--- a/validator/src/validation/length.rs
+++ b/validator/src/validation/length.rs
@@ -68,6 +68,15 @@ mod tests {
     }
 
     #[test]
+    fn test_validate_length_cow_unicode_chars() {
+        let test: Cow<'static, str> = "日本".into();
+        assert!(validate_length(test, None, None, Some(2)));
+
+        let test: Cow<'static, str> = String::from("日本").into();
+        assert!(validate_length(test, None, None, Some(2)));
+    }
+
+    #[test]
     fn test_validate_length_vec() {
         assert!(validate_length(vec![1, 2, 3], None, None, Some(3)));
     }


### PR DESCRIPTION
Updated `HasLen` implementation for `Cow<'a, str>` so that it matches the other `String` types.