### PR TITLE
Use generics and macros

### DIFF
--- a/validator/src/lib.rs
+++ b/validator/src/lib.rs
@@ -82,7 +82,7 @@ pub use validation::regex::ValidateRegex;
 pub use validation::required::ValidateRequired;
 pub use validation::urls::ValidateUrl;
 
-pub use traits::{HasLen, Validate, ValidateArgs};
+pub use traits::{Validate, ValidateArgs};
 pub use types::{ValidationError, ValidationErrors, ValidationErrorsKind};
 
 #[cfg(feature = "derive")]

--- a/validator/src/traits.rs
+++ b/validator/src/traits.rs
@@ -1,92 +1,4 @@
-use std::{
-    borrow::Cow,
-    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
-    rc::Rc,
-    sync::Arc,
-};
-use std::cell::{Ref, RefMut};
-use std::collections::VecDeque;
-
-#[cfg(feature = "indexmap")]
-use indexmap::{IndexMap, IndexSet};
-
 use crate::types::ValidationErrors;
-
-/// Trait to implement if one wants to make the `length` validator
-/// work for more types
-///
-/// A bit sad it's not there by default in Rust
-pub trait HasLen {
-    fn length(&self) -> u64;
-}
-
-macro_rules! impl_type_that_derefs {
-    ($type_:ty) => {
-        impl<T> HasLen for $type_
-        where T: HasLen {
-            fn length(&self) -> u64 {
-                T::length(self)
-            }
-        }
-    };
-}
-
-impl_type_that_derefs!(&T);
-impl_type_that_derefs!(Arc<T>);
-impl_type_that_derefs!(Box<T>);
-impl_type_that_derefs!(Rc<T>);
-impl_type_that_derefs!(Ref<'_, T>);
-impl_type_that_derefs!(RefMut<'_, T>);
-
-macro_rules! impl_type_with_chars {
-    ($type_:ty) => {
-        impl HasLen for $type_ {
-            fn length(&self) -> u64 {
-                self.chars().count() as u64
-            }
-        }
-    };
-}
-
-impl_type_with_chars!(str);
-impl_type_with_chars!(&str);
-impl_type_with_chars!(String);
-
-macro_rules! impl_type_with_len {
-    ($type_:ty, $($generic:ident),*$(,)*) => {
-        impl<$($generic),*> HasLen for $type_ {
-            fn length(&self) -> u64 {
-                self.len() as u64
-            }
-        }
-    };
-}
-
-impl_type_with_len!([T], T);
-impl_type_with_len!(BTreeSet<T>, T);
-impl_type_with_len!(BTreeMap<K, V>, K, V);
-impl_type_with_len!(HashSet<T, S>, T, S);
-impl_type_with_len!(HashMap<K, V, S>, K, V, S);
-impl_type_with_len!(Vec<T>, T);
-impl_type_with_len!(VecDeque<T>, T);
-#[cfg(feature = "indexmap")]
-impl_type_with_len!(IndexSet<T>, T);
-#[cfg(feature = "indexmap")]
-impl_type_with_len!(IndexMap<K, V>, K, V);
-
-impl<'cow, T> HasLen for Cow<'cow, T>
-    where T: ToOwned + ?Sized,
-          for<'a> &'a T: HasLen {
-    fn length(&self) -> u64 {
-        self.as_ref().length()
-    }
-}
-
-impl<T, const N: usize> HasLen for [T; N] {
-    fn length(&self) -> u64 {
-        N as u64
-    }
-}
 
 /// This is the original trait that was implemented by deriving `Validate`. It will still be
 /// implemented for struct validations that don't take custom arguments. The call is being
@@ -97,7 +9,7 @@ pub trait Validate {
 
 impl<T: Validate> Validate for &T {
     fn validate(&self) -> Result<(), ValidationErrors> {
-        T::validate(*self)
+        T::validate(self)
     }
 }
 

--- a/validator/src/validation/contains.rs
+++ b/validator/src/validation/contains.rs
@@ -12,57 +12,30 @@ impl ValidateContains for String {
     }
 }
 
-impl ValidateContains for Option<String> {
+impl<T> ValidateContains for Option<T>
+    where T: ValidateContains {
     fn validate_contains(&self, needle: &str) -> bool {
         if let Some(v) = self {
-            v.contains(needle)
+            v.validate_contains(needle)
         } else {
             true
         }
     }
 }
 
-impl ValidateContains for Option<Option<String>> {
+impl<T> ValidateContains for &T
+    where T: ValidateContains {
     fn validate_contains(&self, needle: &str) -> bool {
-        if let Some(v) = self {
-            if let Some(v) = v {
-                v.contains(needle)
-            } else {
-                true
-            }
-        } else {
-            true
-        }
+        T::validate_contains(self, needle)
     }
 }
 
-impl ValidateContains for &String {
+impl<'cow, T> ValidateContains for Cow<'cow, T>
+    where T: ToOwned + ?Sized,
+          for<'a> &'a T: ValidateContains
+{
     fn validate_contains(&self, needle: &str) -> bool {
-        self.contains(needle)
-    }
-}
-
-impl ValidateContains for Option<&String> {
-    fn validate_contains(&self, needle: &str) -> bool {
-        if let Some(v) = self {
-            v.contains(needle)
-        } else {
-            true
-        }
-    }
-}
-
-impl ValidateContains for Option<Option<&String>> {
-    fn validate_contains(&self, needle: &str) -> bool {
-        if let Some(v) = self {
-            if let Some(v) = v {
-                v.contains(needle)
-            } else {
-                true
-            }
-        } else {
-            true
-        }
+        self.as_ref().validate_contains(needle)
     }
 }
 
@@ -72,117 +45,9 @@ impl<'a> ValidateContains for &'a str {
     }
 }
 
-impl<'a> ValidateContains for Option<&'a str> {
-    fn validate_contains(&self, needle: &str) -> bool {
-        if let Some(v) = self {
-            v.contains(needle)
-        } else {
-            true
-        }
-    }
-}
-
-impl<'a> ValidateContains for Option<Option<&'a str>> {
-    fn validate_contains(&self, needle: &str) -> bool {
-        if let Some(v) = self {
-            if let Some(v) = v {
-                v.contains(needle)
-            } else {
-                true
-            }
-        } else {
-            true
-        }
-    }
-}
-
-impl<'a> ValidateContains for Cow<'a, str> {
-    fn validate_contains(&self, needle: &str) -> bool {
-        self.contains(needle)
-    }
-}
-
-impl<'a> ValidateContains for Option<Cow<'a, str>> {
-    fn validate_contains(&self, needle: &str) -> bool {
-        if let Some(v) = self {
-            v.contains(needle)
-        } else {
-            true
-        }
-    }
-}
-
-impl<'a> ValidateContains for Option<Option<Cow<'a, str>>> {
-    fn validate_contains(&self, needle: &str) -> bool {
-        if let Some(v) = self {
-            if let Some(v) = v {
-                v.contains(needle)
-            } else {
-                true
-            }
-        } else {
-            true
-        }
-    }
-}
-
 impl<S, H: BuildHasher> ValidateContains for HashMap<String, S, H> {
     fn validate_contains(&self, needle: &str) -> bool {
         self.contains_key(needle)
-    }
-}
-
-impl<S, H: BuildHasher> ValidateContains for Option<HashMap<String, S, H>> {
-    fn validate_contains(&self, needle: &str) -> bool {
-        if let Some(v) = self {
-            v.contains_key(needle)
-        } else {
-            true
-        }
-    }
-}
-
-impl<S, H: BuildHasher> ValidateContains for Option<Option<HashMap<String, S, H>>> {
-    fn validate_contains(&self, needle: &str) -> bool {
-        if let Some(v) = self {
-            if let Some(v) = v {
-                v.contains_key(needle)
-            } else {
-                true
-            }
-        } else {
-            true
-        }
-    }
-}
-
-impl<'a, S, H: BuildHasher> ValidateContains for &'a HashMap<String, S, H> {
-    fn validate_contains(&self, needle: &str) -> bool {
-        self.contains_key(needle)
-    }
-}
-
-impl<'a, S, H: BuildHasher> ValidateContains for Option<&'a HashMap<String, S, H>> {
-    fn validate_contains(&self, needle: &str) -> bool {
-        if let Some(v) = self {
-            v.contains_key(needle)
-        } else {
-            true
-        }
-    }
-}
-
-impl<'a, S, H: BuildHasher> ValidateContains for Option<Option<&'a HashMap<String, S, H>>> {
-    fn validate_contains(&self, needle: &str) -> bool {
-        if let Some(v) = self {
-            if let Some(v) = v {
-                v.contains_key(needle)
-            } else {
-                true
-            }
-        } else {
-            true
-        }
     }
 }
 

--- a/validator/src/validation/email.rs
+++ b/validator/src/validation/email.rs
@@ -39,7 +39,7 @@ fn validate_domain_part(domain_part: &str) -> bool {
 /// that are unfamiliar to most users.
 pub trait ValidateEmail {
     fn validate_email(&self) -> bool {
-        let val = if let Some(v) = self.as_email_string() { v } else { return true };
+        let val = if let Some(v) = self.as_email_string() { v } else { return true; };
 
         if val.is_empty() || !val.contains('@') {
             return false;
@@ -75,47 +75,28 @@ pub trait ValidateEmail {
     fn as_email_string(&self) -> Option<Cow<str>>;
 }
 
+impl<T> ValidateEmail for &T
+    where T: ValidateEmail {
+    fn as_email_string(&self) -> Option<Cow<str>> {
+        T::as_email_string(self)
+    }
+}
+
 impl ValidateEmail for String {
     fn as_email_string(&self) -> Option<Cow<str>> {
         Some(Cow::from(self))
     }
 }
 
-impl ValidateEmail for Option<String> {
+impl<T> ValidateEmail for Option<T>
+    where
+        T: ValidateEmail, {
     fn as_email_string(&self) -> Option<Cow<str>> {
-        self.as_ref().map(Cow::from)
-    }
-}
+        let Some(u) = self else {
+            return None;
+        };
 
-impl ValidateEmail for Option<Option<String>> {
-    fn as_email_string(&self) -> Option<Cow<str>> {
-        if let Some(u) = self {
-            u.as_ref().map(Cow::from)
-        } else {
-            None
-        }
-    }
-}
-
-impl ValidateEmail for &String {
-    fn as_email_string(&self) -> Option<Cow<str>> {
-        Some(Cow::from(self.as_str()))
-    }
-}
-
-impl ValidateEmail for Option<&String> {
-    fn as_email_string(&self) -> Option<Cow<str>> {
-        self.as_ref().map(|u| Cow::from(*u))
-    }
-}
-
-impl ValidateEmail for Option<Option<&String>> {
-    fn as_email_string(&self) -> Option<Cow<str>> {
-        if let Some(u) = self {
-            u.as_ref().map(|u| Cow::from(*u))
-        } else {
-            None
-        }
+        T::as_email_string(u)
     }
 }
 
@@ -125,41 +106,9 @@ impl<'a> ValidateEmail for &'a str {
     }
 }
 
-impl<'a> ValidateEmail for Option<&'a str> {
-    fn as_email_string(&self) -> Option<Cow<str>> {
-        self.as_ref().map(|u| Cow::from(*u))
-    }
-}
-
-impl<'a> ValidateEmail for Option<Option<&'a str>> {
-    fn as_email_string(&self) -> Option<Cow<str>> {
-        if let Some(u) = self {
-            u.as_ref().map(|u| Cow::from(*u))
-        } else {
-            None
-        }
-    }
-}
-
 impl ValidateEmail for Cow<'_, str> {
     fn as_email_string(&self) -> Option<Cow<'_, str>> {
         Some(self.clone())
-    }
-}
-
-impl ValidateEmail for Option<Cow<'_, str>> {
-    fn as_email_string(&self) -> Option<Cow<str>> {
-        self.as_ref().map(|u| u.clone())
-    }
-}
-
-impl ValidateEmail for Option<Option<Cow<'_, str>>> {
-    fn as_email_string(&self) -> Option<Cow<str>> {
-        if let Some(u) = self {
-            u.as_ref().map(|u| u.clone())
-        } else {
-            None
-        }
     }
 }
 

--- a/validator/src/validation/email.rs
+++ b/validator/src/validation/email.rs
@@ -3,7 +3,7 @@ use lazy_static::lazy_static;
 use regex::Regex;
 use std::borrow::Cow;
 
-use crate::{HasLen, ValidateIp};
+use crate::{ValidateIp};
 
 lazy_static! {
     // Regex from the specs
@@ -53,7 +53,7 @@ pub trait ValidateEmail {
         // according to RFC5321 the max length of the local part is 64 characters
         // and the max length of the domain part is 255 characters
         // https://datatracker.ietf.org/doc/html/rfc5321#section-4.5.3.1.1
-        if user_part.length() > 64 || domain_part.length() > 255 {
+        if user_part.chars().count() > 64 || domain_part.chars().count() > 255 {
             return false;
         }
 

--- a/validator/src/validation/regex.rs
+++ b/validator/src/validation/regex.rs
@@ -14,9 +14,10 @@ impl AsRegex for Regex {
     }
 }
 
-impl AsRegex for &Regex {
+impl<T> AsRegex for &T
+    where T: AsRegex {
     fn as_regex(&self) -> Cow<Regex> {
-        Cow::Borrowed(self)
+        T::as_regex(self)
     }
 }
 
@@ -54,122 +55,41 @@ pub trait ValidateRegex {
     fn validate_regex(&self, regex: impl AsRegex) -> bool;
 }
 
+impl<T> ValidateRegex for &T
+    where T: ValidateRegex {
+    fn validate_regex(&self, regex: impl AsRegex) -> bool {
+        T::validate_regex(self, regex)
+    }
+}
+
+impl<T> ValidateRegex for Option<T>
+    where T: ValidateRegex {
+    fn validate_regex(&self, regex: impl AsRegex) -> bool {
+        if let Some(h) = self {
+            T::validate_regex(h, regex)
+        } else {
+            true
+        }
+    }
+}
+
+impl<'cow, T> ValidateRegex for Cow<'cow, T>
+    where T: ToOwned + ?Sized,
+          for<'a> &'a T: ValidateRegex
+{
+    fn validate_regex(&self, regex: impl AsRegex) -> bool {
+        self.as_ref().validate_regex(regex)
+    }
+}
+
 impl ValidateRegex for String {
     fn validate_regex(&self, regex: impl AsRegex) -> bool {
         regex.as_regex().is_match(self)
     }
 }
 
-impl ValidateRegex for Option<String> {
-    fn validate_regex(&self, regex: impl AsRegex) -> bool {
-        if let Some(h) = self {
-            regex.as_regex().is_match(h)
-        } else {
-            true
-        }
-    }
-}
-
-impl ValidateRegex for Option<Option<String>> {
-    fn validate_regex(&self, regex: impl AsRegex) -> bool {
-        if let Some(h) = self {
-            if let Some(h) = h {
-                regex.as_regex().is_match(h)
-            } else {
-                true
-            }
-        } else {
-            true
-        }
-    }
-}
-
-impl ValidateRegex for &String {
-    fn validate_regex(&self, regex: impl AsRegex) -> bool {
-        regex.as_regex().is_match(self)
-    }
-}
-
-impl ValidateRegex for Option<&String> {
-    fn validate_regex(&self, regex: impl AsRegex) -> bool {
-        if let Some(h) = self {
-            regex.as_regex().is_match(h)
-        } else {
-            true
-        }
-    }
-}
-
-impl ValidateRegex for Option<Option<&String>> {
-    fn validate_regex(&self, regex: impl AsRegex) -> bool {
-        if let Some(h) = self {
-            if let Some(h) = h {
-                regex.as_regex().is_match(h)
-            } else {
-                true
-            }
-        } else {
-            true
-        }
-    }
-}
-
 impl ValidateRegex for &str {
     fn validate_regex(&self, regex: impl AsRegex) -> bool {
         regex.as_regex().is_match(self)
-    }
-}
-
-impl ValidateRegex for Option<&str> {
-    fn validate_regex(&self, regex: impl AsRegex) -> bool {
-        if let Some(h) = self {
-            regex.as_regex().is_match(h)
-        } else {
-            true
-        }
-    }
-}
-
-impl ValidateRegex for Option<Option<&str>> {
-    fn validate_regex(&self, regex: impl AsRegex) -> bool {
-        if let Some(h) = self {
-            if let Some(h) = h {
-                regex.as_regex().is_match(h)
-            } else {
-                true
-            }
-        } else {
-            true
-        }
-    }
-}
-
-impl ValidateRegex for Cow<'_, str> {
-    fn validate_regex(&self, regex: impl AsRegex) -> bool {
-        regex.as_regex().is_match(self)
-    }
-}
-
-impl ValidateRegex for Option<Cow<'_, str>> {
-    fn validate_regex(&self, regex: impl AsRegex) -> bool {
-        if let Some(h) = self {
-            regex.as_regex().is_match(h)
-        } else {
-            true
-        }
-    }
-}
-
-impl ValidateRegex for Option<Option<Cow<'_, str>>> {
-    fn validate_regex(&self, regex: impl AsRegex) -> bool {
-        if let Some(h) = self {
-            if let Some(h) = h {
-                regex.as_regex().is_match(h)
-            } else {
-                true
-            }
-        } else {
-            true
-        }
     }
 }

--- a/validator_derive/src/types.rs
+++ b/validator_derive/src/types.rs
@@ -37,7 +37,7 @@ pub struct ValidateField {
 }
 
 impl ValidateField {
-    pub fn validate(&self, struct_ident: &Ident, all_fields: &Vec<&Field>, current_field: &Field) {
+    pub fn validate(&self, struct_ident: &Ident, all_fields: &[&Field], current_field: &Field) {
         let field_name = self.ident.clone().expect("Field is not a named field").to_string();
         let field_attrs = &current_field.attrs;
 

--- a/validator_derive/src/utils.rs
+++ b/validator_derive/src/utils.rs
@@ -129,10 +129,10 @@ pub fn quote_use_stmts(fields: &Vec<ValidateField>) -> proc_macro2::TokenStream 
     )
 }
 
-pub fn get_attr<'a>(attrs: &'a Vec<Attribute>, name: &str) -> Option<&'a Attribute> {
+pub fn get_attr<'a>(attrs: &'a [Attribute], name: &str) -> Option<&'a Attribute> {
     attrs.iter().find(|a| match &a.meta {
         syn::Meta::List(list) => list.tokens.clone().into_iter().any(|t| match t {
-            proc_macro2::TokenTree::Ident(i) => &i.to_string() == name,
+            proc_macro2::TokenTree::Ident(i) => i == name,
             _ => false,
         }),
         _ => false,


### PR DESCRIPTION
This also implements #271 on next which is included in the code changes related to `HasLen`, though I don't see how `HasLen` is used in this branch.

Most of the code was eliminated by using generic implementations for `Option<T>` and `&T`.