### PR TITLE
tests: fix expected errors for Rust 1.75

### DIFF
--- a/validator_derive_tests/tests/compile-fail/custom/validate_not_impl_with_args.stderr
+++ b/validator_derive_tests/tests/compile-fail/custom/validate_not_impl_with_args.stderr
@@ -2,7 +2,7 @@ error[E0599]: no method named `validate` found for struct `Test` in the current 
   --> $DIR/validate_not_impl_with_args.rs:15:10
    |
 8  | struct Test {
-   | ----------- method `validate` not found for this
+   | ----------- method `validate` not found for this struct
 ...
 15 |     test.validate();
    |          ^^^^^^^^ method not found in `Test`

--- a/validator_derive_tests/tests/compile-fail/no_nested_validations.stderr
+++ b/validator_derive_tests/tests/compile-fail/no_nested_validations.stderr
@@ -5,7 +5,7 @@ error[E0599]: no method named `validate` found for struct `Nested` in the curren
   |          ^^^^^^^^ method not found in `Nested`
 ...
 9 | struct Nested {
-  | ------------- method `validate` not found for this
+  | ------------- method `validate` not found for this struct
   |
   = help: items from traits can only be used if the trait is implemented and in scope
   = note: the following trait defines an item `validate`, perhaps you need to implement it:


### PR DESCRIPTION
Rust 1.75 has a change in error messages for methods on structs.