### PR TITLE
fix: darling unexpected literal type error

### DIFF
--- a/validator_derive/src/lib.rs
+++ b/validator_derive/src/lib.rs
@@ -225,7 +225,7 @@ impl ToTokens for ValidateField {
 // The "supports(struct_named)" attribute guarantees only named structs to work with this macro
 #[derive(Debug, FromDeriveInput)]
 #[darling(attributes(validate), supports(struct_named))]
-#[darling(and_then = ValidationData::validate)]
+#[darling(and_then = "ValidationData::validate")]
 struct ValidationData {
     ident: syn::Ident,
     generics: syn::Generics,


### PR DESCRIPTION
Hello!

When updating my dependency of validator from 0.16.1 to 0.18.1, I got the following error:

```
error: Unexpected literal type `path`
   --> /home/tvincent/.cargo/registry/src/index.crates.io-6f17d22bba15001f/validator_derive-0.18.1/src/lib.rs:228:22
    |
228 | #[darling(and_then = ValidationData::validate)]
    |                      ^^^^^^^^^^^^^^
```

From [darling's README](https://github.com/TedDriggs/darling?tab=readme-ov-file#features), it looks like the path given to `and_then` should be within double quotes, and indeed it fixed my build issue.

This PR simply adds the missing double quotes.

Thanks for making and taking care of validator (and zola!).