### PR TITLE
Publish AsRegex

### DIFF
--- a/validator/src/lib.rs
+++ b/validator/src/lib.rs
@@ -76,7 +76,7 @@ pub use validation::must_match::validate_must_match;
 #[cfg(feature = "unic")]
 pub use validation::non_control_character::ValidateNonControlCharacter;
 pub use validation::range::ValidateRange;
-pub use validation::regex::ValidateRegex;
+pub use validation::regex::{ValidateRegex, AsRegex};
 pub use validation::required::ValidateRequired;
 pub use validation::urls::ValidateUrl;
 


### PR DESCRIPTION
Hi,
I wanted to add the ValidateRegex trait to a custom struct. However I was unable to do so because the regex parameter of the validate_regex function is declared as impl AsRegex. That trait is not reexported.