### PR TITLE
Make ValidationErrors ordered

### DIFF
--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -21,7 +21,7 @@ serde_json = "1"
 validator_derive = { version = "0.18", path = "../validator_derive", optional = true }
 card-validate = { version = "2.3", optional = true }
 unic-ucd-common = { version = "0.9", optional = true }
-indexmap = { version = "2.0.0", features = ["serde"], optional = true }
+indexmap = { version = "2.0.0", features = ["serde"] }
 
 [features]
 card = ["card-validate"]

--- a/validator/src/traits.rs
+++ b/validator/src/traits.rs
@@ -1,6 +1,7 @@
 use crate::types::{ValidationErrors, ValidationErrorsKind};
 use std::collections::btree_map::BTreeMap;
 use std::collections::HashMap;
+use indexmap::IndexMap;
 
 /// This is the original trait that was implemented by deriving `Validate`. It will still be
 /// implemented for struct validations that don't take custom arguments. The call is being
@@ -31,7 +32,7 @@ macro_rules! impl_validate_list {
                     Ok(())
                 } else {
                     let err_kind = ValidationErrorsKind::List(vec_err);
-                    let errors = ValidationErrors(std::collections::HashMap::from([(
+                    let errors = ValidationErrors(indexmap::IndexMap::from([(
                         "_tmp_validator",
                         err_kind,
                     )]));
@@ -65,7 +66,7 @@ impl<T: Validate, const N: usize> Validate for [T; N] {
         } else {
             let err_kind = ValidationErrorsKind::List(vec_err);
             let errors =
-                ValidationErrors(std::collections::HashMap::from([("_tmp_validator", err_kind)]));
+                ValidationErrors(indexmap::IndexMap::from([("_tmp_validator", err_kind)]));
             Err(errors)
         }
     }
@@ -85,7 +86,7 @@ impl<K, V: Validate, S> Validate for &HashMap<K, V, S> {
             Ok(())
         } else {
             let err_kind = ValidationErrorsKind::List(vec_err);
-            let errors = ValidationErrors(HashMap::from([("_tmp_validator", err_kind)]));
+            let errors = ValidationErrors(IndexMap::from([("_tmp_validator", err_kind)]));
             Err(errors)
         }
     }
@@ -105,7 +106,7 @@ impl<K, V: Validate> Validate for &BTreeMap<K, V> {
             Ok(())
         } else {
             let err_kind = ValidationErrorsKind::List(vec_err);
-            let errors = ValidationErrors(HashMap::from([("_tmp_validator", err_kind)]));
+            let errors = ValidationErrors(IndexMap::from([("_tmp_validator", err_kind)]));
             Err(errors)
         }
     }

--- a/validator_derive_tests/Cargo.toml
+++ b/validator_derive_tests/Cargo.toml
@@ -13,7 +13,6 @@ validator = { version = "0.18", path = "../validator", features = [
     "card",
     "unic",
     "derive",
-    "indexmap",
 ] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -22,4 +21,4 @@ regex = "1"
 once_cell = "1.18.0"
 
 [dependencies]
-indexmap = { version = "2", features = ["serde"], optional = true }
+indexmap = { version = "2", features = ["serde"] }


### PR DESCRIPTION
*Just an idea, maybe there is a better solution*

To solve https://github.com/Keats/validator/issues/286 , use IndexMap instead of HashMap in ValidationErrors.