### PR TITLE
feat: add `#[validator(crate = "...")]` for crate alias

### DIFF
--- a/validator_derive/src/lib.rs
+++ b/validator_derive/src/lib.rs
@@ -259,7 +259,7 @@ struct ValidationData {
 }
 
 #[derive(Debug, Clone)]
-struct CrateName {
+pub(crate) struct CrateName {
     inner: Path,
 }
 

--- a/validator_derive/src/lib.rs
+++ b/validator_derive/src/lib.rs
@@ -21,7 +21,7 @@ use tokens::required::required_tokens;
 use tokens::schema::schema_tokens;
 use tokens::url::url_tokens;
 use types::*;
-use utils::quote_use_stmts;
+use utils::{quote_use_stmts, CrateName};
 
 mod tokens;
 mod types;
@@ -256,37 +256,6 @@ struct ValidationData {
     /// defaults to `validator`.
     #[darling(rename = "crate", default)]
     crate_name: CrateName,
-}
-
-#[derive(Debug, Clone)]
-pub(crate) struct CrateName {
-    inner: Path,
-}
-
-impl ToTokens for CrateName {
-    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
-        self.inner.to_tokens(tokens);
-    }
-}
-
-impl darling::FromMeta for CrateName {
-    fn from_string(value: &str) -> darling::Result<Self> {
-        Path::from_string(value).map(|inner| CrateName { inner })
-    }
-
-    fn from_value(value: &syn::Lit) -> darling::Result<Self> {
-        Path::from_value(value).map(|inner| CrateName { inner })
-    }
-
-    fn from_expr(value: &syn::Expr) -> darling::Result<Self> {
-        Path::from_expr(value).map(|inner| CrateName { inner })
-    }
-}
-
-impl Default for CrateName {
-    fn default() -> Self {
-        CrateName { inner: syn::parse_str("::validator").expect("invalid valid crate name") }
-    }
 }
 
 impl ValidationData {

--- a/validator_derive/src/lib.rs
+++ b/validator_derive/src/lib.rs
@@ -285,7 +285,7 @@ impl darling::FromMeta for CrateName {
 
 impl Default for CrateName {
     fn default() -> Self {
-        CrateName { inner: syn::parse_str("validator").expect("invalid valid crate name") }
+        CrateName { inner: syn::parse_str("::validator").expect("invalid valid crate name") }
     }
 }
 
@@ -425,9 +425,9 @@ pub fn derive_validation(input: proc_macro::TokenStream) -> proc_macro::TokenStr
 
     let argless_validation = if validation_data.context.is_none() {
         quote! {
-            impl #imp ::#crate_name::Validate for #ident #ty #whr {
-                fn validate(&self) -> ::std::result::Result<(), ::#crate_name::ValidationErrors> {
-                    use ::#crate_name::ValidateArgs;
+            impl #imp #crate_name::Validate for #ident #ty #whr {
+                fn validate(&self) -> ::std::result::Result<(), #crate_name::ValidationErrors> {
+                    use #crate_name::ValidateArgs;
                     self.validate_with_args(())
                 }
             }
@@ -439,15 +439,15 @@ pub fn derive_validation(input: proc_macro::TokenStream) -> proc_macro::TokenStr
     quote!(
         #argless_validation
 
-        impl #imp_args ::#crate_name::ValidateArgs<'v_a> for #ident #ty #whr {
+        impl #imp_args #crate_name::ValidateArgs<'v_a> for #ident #ty #whr {
             type Args = #custom_context;
 
             fn validate_with_args(&self, args: Self::Args)
-            -> ::std::result::Result<(), ::#crate_name::ValidationErrors>
+            -> ::std::result::Result<(), #crate_name::ValidationErrors>
              {
                 #use_statements
 
-                let mut errors = ::#crate_name::ValidationErrors::new();
+                let mut errors = #crate_name::ValidationErrors::new();
 
                 #(#validation_fields)*
 

--- a/validator_derive/src/tokens/cards.rs
+++ b/validator_derive/src/tokens/cards.rs
@@ -1,8 +1,7 @@
 use quote::quote;
 
 use crate::types::Card;
-use crate::utils::{quote_code, quote_message};
-use crate::CrateName;
+use crate::utils::{quote_code, quote_message, CrateName};
 
 pub fn credit_card_tokens(
     crate_name: &CrateName,

--- a/validator_derive/src/tokens/cards.rs
+++ b/validator_derive/src/tokens/cards.rs
@@ -2,14 +2,16 @@ use quote::quote;
 
 use crate::types::Card;
 use crate::utils::{quote_code, quote_message};
+use crate::CrateName;
 
 pub fn credit_card_tokens(
+    crate_name: &CrateName,
     credit_card: Card,
     field_name: &proc_macro2::TokenStream,
     field_name_str: &str,
 ) -> proc_macro2::TokenStream {
     let message = quote_message(credit_card.message);
-    let code = quote_code(credit_card.code, "credit_card");
+    let code = quote_code(crate_name, credit_card.code, "credit_card");
 
     quote! {
         if !#field_name.validate_credit_card() {

--- a/validator_derive/src/tokens/contains.rs
+++ b/validator_derive/src/tokens/contains.rs
@@ -2,8 +2,10 @@ use quote::quote;
 
 use crate::types::Contains;
 use crate::utils::{quote_code, quote_message};
+use crate::CrateName;
 
 pub fn contains_tokens(
+    crate_name: &CrateName,
     contains: Contains,
     field_name: &proc_macro2::TokenStream,
     field_name_str: &str,
@@ -13,7 +15,7 @@ pub fn contains_tokens(
         (quote!(#p), quote!(err.add_param(::std::borrow::Cow::from("needle"), &#p);));
 
     let message = quote_message(contains.message);
-    let code = quote_code(contains.code, "contains");
+    let code = quote_code(crate_name, contains.code, "contains");
 
     quote! {
         if !#field_name.validate_contains(#needle) {

--- a/validator_derive/src/tokens/contains.rs
+++ b/validator_derive/src/tokens/contains.rs
@@ -1,8 +1,7 @@
 use quote::quote;
 
 use crate::types::Contains;
-use crate::utils::{quote_code, quote_message};
-use crate::CrateName;
+use crate::utils::{quote_code, quote_message, CrateName};
 
 pub fn contains_tokens(
     crate_name: &CrateName,

--- a/validator_derive/src/tokens/does_not_contain.rs
+++ b/validator_derive/src/tokens/does_not_contain.rs
@@ -2,8 +2,10 @@ use quote::quote;
 
 use crate::types::DoesNotContain;
 use crate::utils::{quote_code, quote_message};
+use crate::CrateName;
 
 pub fn does_not_contain_tokens(
+    crate_name: &CrateName,
     does_not_contain: DoesNotContain,
     field_name: &proc_macro2::TokenStream,
     field_name_str: &str,
@@ -14,7 +16,7 @@ pub fn does_not_contain_tokens(
         (quote!(#p), quote!(err.add_param(::std::borrow::Cow::from("needle"), &#p);));
 
     let message = quote_message(does_not_contain.message);
-    let code = quote_code(does_not_contain.code, "does_not_contain");
+    let code = quote_code(crate_name, does_not_contain.code, "does_not_contain");
 
     quote! {
         if !#field_name.validate_does_not_contain(#needle) {

--- a/validator_derive/src/tokens/does_not_contain.rs
+++ b/validator_derive/src/tokens/does_not_contain.rs
@@ -1,8 +1,7 @@
 use quote::quote;
 
 use crate::types::DoesNotContain;
-use crate::utils::{quote_code, quote_message};
-use crate::CrateName;
+use crate::utils::{quote_code, quote_message, CrateName};
 
 pub fn does_not_contain_tokens(
     crate_name: &CrateName,

--- a/validator_derive/src/tokens/email.rs
+++ b/validator_derive/src/tokens/email.rs
@@ -2,14 +2,16 @@ use quote::quote;
 
 use crate::types::Email;
 use crate::utils::{quote_code, quote_message};
+use crate::CrateName;
 
 pub fn email_tokens(
+    crate_name: &CrateName,
     email: Email,
     field_name: &proc_macro2::TokenStream,
     field_name_str: &str,
 ) -> proc_macro2::TokenStream {
     let message = quote_message(email.message);
-    let code = quote_code(email.code, "email");
+    let code = quote_code(crate_name, email.code, "email");
 
     quote! {
         if !#field_name.validate_email() {

--- a/validator_derive/src/tokens/email.rs
+++ b/validator_derive/src/tokens/email.rs
@@ -1,8 +1,7 @@
 use quote::quote;
 
 use crate::types::Email;
-use crate::utils::{quote_code, quote_message};
-use crate::CrateName;
+use crate::utils::{quote_code, quote_message, CrateName};
 
 pub fn email_tokens(
     crate_name: &CrateName,

--- a/validator_derive/src/tokens/ip.rs
+++ b/validator_derive/src/tokens/ip.rs
@@ -2,14 +2,16 @@ use quote::quote;
 
 use crate::types::Ip;
 use crate::utils::{quote_code, quote_message};
+use crate::CrateName;
 
 pub fn ip_tokens(
+    crate_name: &CrateName,
     ip: Ip,
     field_name: &proc_macro2::TokenStream,
     field_name_str: &str,
 ) -> proc_macro2::TokenStream {
     let message = quote_message(ip.message);
-    let code = quote_code(ip.code, "ip");
+    let code = quote_code(crate_name, ip.code, "ip");
 
     let version = match (ip.v4, ip.v6) {
         (Some(v4), Some(v6)) => match (v4, v6) {

--- a/validator_derive/src/tokens/ip.rs
+++ b/validator_derive/src/tokens/ip.rs
@@ -1,8 +1,7 @@
 use quote::quote;
 
 use crate::types::Ip;
-use crate::utils::{quote_code, quote_message};
-use crate::CrateName;
+use crate::utils::{quote_code, quote_message, CrateName};
 
 pub fn ip_tokens(
     crate_name: &CrateName,

--- a/validator_derive/src/tokens/length.rs
+++ b/validator_derive/src/tokens/length.rs
@@ -1,8 +1,7 @@
 use quote::quote;
 
 use crate::types::Length;
-use crate::utils::{quote_code, quote_message};
-use crate::CrateName;
+use crate::utils::{quote_code, quote_message, CrateName};
 
 pub fn length_tokens(
     crate_name: &CrateName,

--- a/validator_derive/src/tokens/length.rs
+++ b/validator_derive/src/tokens/length.rs
@@ -2,8 +2,10 @@ use quote::quote;
 
 use crate::types::Length;
 use crate::utils::{quote_code, quote_message};
+use crate::CrateName;
 
 pub fn length_tokens(
+    crate_name: &CrateName,
     length: Length,
     field_name: &proc_macro2::TokenStream,
     field_name_str: &str,
@@ -25,7 +27,7 @@ pub fn length_tokens(
     };
 
     let message = quote_message(length.message);
-    let code = quote_code(length.code, "length");
+    let code = quote_code(crate_name, length.code, "length");
 
     quote! {
         if !#field_name.validate_length(#min, #max, #equal) {

--- a/validator_derive/src/tokens/must_match.rs
+++ b/validator_derive/src/tokens/must_match.rs
@@ -2,8 +2,10 @@ use quote::quote;
 
 use crate::types::MustMatch;
 use crate::utils::{quote_code, quote_message};
+use crate::CrateName;
 
 pub fn must_match_tokens(
+    crate_name: &CrateName,
     must_match: MustMatch,
     field_name: &proc_macro2::TokenStream,
     field_name_str: &str,
@@ -13,10 +15,10 @@ pub fn must_match_tokens(
         (quote!(self.#o), quote!(err.add_param(::std::borrow::Cow::from("other"), &self.#o);));
 
     let message = quote_message(must_match.message);
-    let code = quote_code(must_match.code, "must_match");
+    let code = quote_code(crate_name, must_match.code, "must_match");
 
     quote! {
-        if !::validator::validate_must_match(&#field_name, &#other) {
+        if !::#crate_name::validate_must_match(&#field_name, &#other) {
             #code
             #message
             #other_err

--- a/validator_derive/src/tokens/must_match.rs
+++ b/validator_derive/src/tokens/must_match.rs
@@ -1,8 +1,7 @@
 use quote::quote;
 
 use crate::types::MustMatch;
-use crate::utils::{quote_code, quote_message};
-use crate::CrateName;
+use crate::utils::{quote_code, quote_message, CrateName};
 
 pub fn must_match_tokens(
     crate_name: &CrateName,

--- a/validator_derive/src/tokens/must_match.rs
+++ b/validator_derive/src/tokens/must_match.rs
@@ -18,7 +18,7 @@ pub fn must_match_tokens(
     let code = quote_code(crate_name, must_match.code, "must_match");
 
     quote! {
-        if !::#crate_name::validate_must_match(&#field_name, &#other) {
+        if !#crate_name::validate_must_match(&#field_name, &#other) {
             #code
             #message
             #other_err

--- a/validator_derive/src/tokens/non_control_character.rs
+++ b/validator_derive/src/tokens/non_control_character.rs
@@ -2,14 +2,16 @@ use quote::quote;
 
 use crate::types::NonControlCharacter;
 use crate::utils::{quote_code, quote_message};
+use crate::CrateName;
 
 pub fn non_control_char_tokens(
+    crate_name: &CrateName,
     non_control_char: NonControlCharacter,
     field_name: &proc_macro2::TokenStream,
     field_name_str: &str,
 ) -> proc_macro2::TokenStream {
     let message = quote_message(non_control_char.message);
-    let code = quote_code(non_control_char.code, "non_control_character");
+    let code = quote_code(crate_name, non_control_char.code, "non_control_character");
 
     quote! {
         if !#field_name.validate_non_control_character() {

--- a/validator_derive/src/tokens/non_control_character.rs
+++ b/validator_derive/src/tokens/non_control_character.rs
@@ -1,8 +1,7 @@
 use quote::quote;
 
 use crate::types::NonControlCharacter;
-use crate::utils::{quote_code, quote_message};
-use crate::CrateName;
+use crate::utils::{quote_code, quote_message, CrateName};
 
 pub fn non_control_char_tokens(
     crate_name: &CrateName,

--- a/validator_derive/src/tokens/range.rs
+++ b/validator_derive/src/tokens/range.rs
@@ -2,8 +2,10 @@ use quote::quote;
 
 use crate::types::Range;
 use crate::utils::{quote_code, quote_message};
+use crate::CrateName;
 
 pub fn range_tokens(
+    crate_name: &CrateName,
     range: Range,
     field_name: &proc_macro2::TokenStream,
     field_name_str: &str,
@@ -33,7 +35,7 @@ pub fn range_tokens(
     };
 
     let message = quote_message(range.message);
-    let code = quote_code(range.code, "range");
+    let code = quote_code(crate_name, range.code, "range");
 
     quote! {
         if !#field_name.validate_range(#min, #max, #ex_min, #ex_max) {

--- a/validator_derive/src/tokens/range.rs
+++ b/validator_derive/src/tokens/range.rs
@@ -1,8 +1,7 @@
 use quote::quote;
 
 use crate::types::Range;
-use crate::utils::{quote_code, quote_message};
-use crate::CrateName;
+use crate::utils::{quote_code, quote_message, CrateName};
 
 pub fn range_tokens(
     crate_name: &CrateName,

--- a/validator_derive/src/tokens/regex.rs
+++ b/validator_derive/src/tokens/regex.rs
@@ -2,15 +2,17 @@ use quote::quote;
 
 use crate::types::Regex;
 use crate::utils::{quote_code, quote_message};
+use crate::CrateName;
 
 pub fn regex_tokens(
+    crate_name: &CrateName,
     regex: Regex,
     field_name: &proc_macro2::TokenStream,
     field_name_str: &str,
 ) -> proc_macro2::TokenStream {
     let path = regex.path;
     let message = quote_message(regex.message);
-    let code = quote_code(regex.code, "regex");
+    let code = quote_code(crate_name, regex.code, "regex");
 
     quote! {
         if !&#field_name.validate_regex(&#path) {

--- a/validator_derive/src/tokens/regex.rs
+++ b/validator_derive/src/tokens/regex.rs
@@ -1,8 +1,7 @@
 use quote::quote;
 
 use crate::types::Regex;
-use crate::utils::{quote_code, quote_message};
-use crate::CrateName;
+use crate::utils::{quote_code, quote_message, CrateName};
 
 pub fn regex_tokens(
     crate_name: &CrateName,

--- a/validator_derive/src/tokens/required.rs
+++ b/validator_derive/src/tokens/required.rs
@@ -3,14 +3,16 @@ use syn::Ident;
 
 use crate::types::Required;
 use crate::utils::{quote_code, quote_message};
+use crate::CrateName;
 
 pub fn required_tokens(
+    crate_name: &CrateName,
     required: Required,
     field_name: &Ident,
     field_name_str: &str,
 ) -> proc_macro2::TokenStream {
     let message = quote_message(required.message);
-    let code = quote_code(required.code, "required");
+    let code = quote_code(crate_name, required.code, "required");
 
     quote! {
         if !self.#field_name.validate_required() {

--- a/validator_derive/src/tokens/required.rs
+++ b/validator_derive/src/tokens/required.rs
@@ -2,8 +2,7 @@ use quote::quote;
 use syn::Ident;
 
 use crate::types::Required;
-use crate::utils::{quote_code, quote_message};
-use crate::CrateName;
+use crate::utils::{quote_code, quote_message, CrateName};
 
 pub fn required_tokens(
     crate_name: &CrateName,

--- a/validator_derive/src/tokens/url.rs
+++ b/validator_derive/src/tokens/url.rs
@@ -1,8 +1,7 @@
 use quote::quote;
 
 use crate::types::Url;
-use crate::utils::{quote_code, quote_message};
-use crate::CrateName;
+use crate::utils::{quote_code, quote_message, CrateName};
 
 pub fn url_tokens(
     crate_name: &CrateName,

--- a/validator_derive/src/tokens/url.rs
+++ b/validator_derive/src/tokens/url.rs
@@ -2,14 +2,16 @@ use quote::quote;
 
 use crate::types::Url;
 use crate::utils::{quote_code, quote_message};
+use crate::CrateName;
 
 pub fn url_tokens(
+    crate_name: &CrateName,
     url: Url,
     field_name: &proc_macro2::TokenStream,
     field_name_str: &str,
 ) -> proc_macro2::TokenStream {
     let message = quote_message(url.message);
-    let code = quote_code(url.code, "url");
+    let code = quote_code(crate_name, url.code, "url");
 
     quote! {
         if !#field_name.validate_url() {

--- a/validator_derive/src/types.rs
+++ b/validator_derive/src/types.rs
@@ -9,6 +9,7 @@ use syn::spanned::Spanned;
 use syn::{Expr, Field, Ident, Path};
 
 use crate::utils::get_attr;
+use crate::CrateName;
 
 static OPTIONS_TYPE: [&str; 3] = ["Option|", "std|option|Option|", "core|option|Option|"];
 
@@ -67,6 +68,9 @@ pub struct ValidateField {
     pub custom: Vec<Custom>,
     pub skip: Option<bool>,
     pub nested: Option<bool>,
+    /// Placeholder for the crate name, filled in by the [`ValidationData`](crate::ValidationData) value.
+    #[darling(skip)]
+    pub crate_name: CrateName,
 }
 
 impl ValidateField {

--- a/validator_derive/src/types.rs
+++ b/validator_derive/src/types.rs
@@ -8,8 +8,7 @@ use quote::quote;
 use syn::spanned::Spanned;
 use syn::{Expr, Field, Ident, Path};
 
-use crate::utils::get_attr;
-use crate::CrateName;
+use crate::utils::{get_attr, CrateName};
 
 static OPTIONS_TYPE: [&str; 3] = ["Option|", "std|option|Option|", "core|option|Option|"];
 

--- a/validator_derive/src/utils.rs
+++ b/validator_derive/src/utils.rs
@@ -20,11 +20,11 @@ pub fn quote_code(
 ) -> proc_macro2::TokenStream {
     if let Some(c) = code {
         quote!(
-            let mut err = ::#crate_name::ValidationError::new(#c);
+            let mut err = #crate_name::ValidationError::new(#c);
         )
     } else {
         quote!(
-            let mut err = ::#crate_name::ValidationError::new(#default);
+            let mut err = #crate_name::ValidationError::new(#default);
         )
     }
 }
@@ -48,67 +48,67 @@ pub fn quote_use_stmts(
     for f in fields {
         if f.length.is_some() {
             length = quote!(
-                use ::#crate_name::ValidateLength;
+                use #crate_name::ValidateLength;
             );
         }
 
         if f.email.is_some() {
             email = quote!(
-                use ::#crate_name::ValidateEmail;
+                use #crate_name::ValidateEmail;
             );
         }
 
         if f.credit_card.is_some() {
             card = quote!(
-                use ::#crate_name::ValidateCreditCard;
+                use #crate_name::ValidateCreditCard;
             );
         }
 
         if f.url.is_some() {
             url = quote!(
-                use ::#crate_name::ValidateUrl;
+                use #crate_name::ValidateUrl;
             );
         }
 
         if f.ip.is_some() {
             ip = quote!(
-                use ::#crate_name::ValidateIp;
+                use #crate_name::ValidateIp;
             );
         }
 
         if f.non_control_character.is_some() {
             ncc = quote!(
-                use ::#crate_name::ValidateNonControlCharacter;
+                use #crate_name::ValidateNonControlCharacter;
             );
         }
 
         if f.range.is_some() {
             range = quote!(
-                use ::#crate_name::ValidateRange;
+                use #crate_name::ValidateRange;
             );
         }
 
         if f.required.is_some() {
             required = quote!(
-                use ::#crate_name::ValidateRequired;
+                use #crate_name::ValidateRequired;
             );
         }
 
         if f.contains.is_some() {
             contains = quote!(
-                use ::#crate_name::ValidateContains;
+                use #crate_name::ValidateContains;
             );
         }
 
         if f.does_not_contain.is_some() {
             does_not_contain = quote!(
-                use ::#crate_name::ValidateDoesNotContain;
+                use #crate_name::ValidateDoesNotContain;
             );
         }
 
         if f.regex.is_some() {
             regex = quote!(
-                use ::#crate_name::ValidateRegex;
+                use #crate_name::ValidateRegex;
             );
         }
     }

--- a/validator_derive/src/utils.rs
+++ b/validator_derive/src/utils.rs
@@ -1,7 +1,7 @@
 use quote::quote;
 use syn::Attribute;
 
-use crate::ValidateField;
+use crate::{CrateName, ValidateField};
 
 pub fn quote_message(message: Option<String>) -> proc_macro2::TokenStream {
     if let Some(m) = message {
@@ -13,19 +13,26 @@ pub fn quote_message(message: Option<String>) -> proc_macro2::TokenStream {
     }
 }
 
-pub fn quote_code(code: Option<String>, default: &str) -> proc_macro2::TokenStream {
+pub fn quote_code(
+    crate_name: &CrateName,
+    code: Option<String>,
+    default: &str,
+) -> proc_macro2::TokenStream {
     if let Some(c) = code {
         quote!(
-            let mut err = ::validator::ValidationError::new(#c);
+            let mut err = ::#crate_name::ValidationError::new(#c);
         )
     } else {
         quote!(
-            let mut err = ::validator::ValidationError::new(#default);
+            let mut err = ::#crate_name::ValidationError::new(#default);
         )
     }
 }
 
-pub fn quote_use_stmts(fields: &Vec<ValidateField>) -> proc_macro2::TokenStream {
+pub fn quote_use_stmts(
+    crate_name: &CrateName,
+    fields: &Vec<ValidateField>,
+) -> proc_macro2::TokenStream {
     let mut length = quote!();
     let mut email = quote!();
     let mut card = quote!();
@@ -41,67 +48,67 @@ pub fn quote_use_stmts(fields: &Vec<ValidateField>) -> proc_macro2::TokenStream 
     for f in fields {
         if f.length.is_some() {
             length = quote!(
-                use validator::ValidateLength;
+                use ::#crate_name::ValidateLength;
             );
         }
 
         if f.email.is_some() {
             email = quote!(
-                use validator::ValidateEmail;
+                use ::#crate_name::ValidateEmail;
             );
         }
 
         if f.credit_card.is_some() {
             card = quote!(
-                use validator::ValidateCreditCard;
+                use ::#crate_name::ValidateCreditCard;
             );
         }
 
         if f.url.is_some() {
             url = quote!(
-                use validator::ValidateUrl;
+                use ::#crate_name::ValidateUrl;
             );
         }
 
         if f.ip.is_some() {
             ip = quote!(
-                use validator::ValidateIp;
+                use ::#crate_name::ValidateIp;
             );
         }
 
         if f.non_control_character.is_some() {
             ncc = quote!(
-                use validator::ValidateNonControlCharacter;
+                use ::#crate_name::ValidateNonControlCharacter;
             );
         }
 
         if f.range.is_some() {
             range = quote!(
-                use validator::ValidateRange;
+                use ::#crate_name::ValidateRange;
             );
         }
 
         if f.required.is_some() {
             required = quote!(
-                use validator::ValidateRequired;
+                use ::#crate_name::ValidateRequired;
             );
         }
 
         if f.contains.is_some() {
             contains = quote!(
-                use validator::ValidateContains;
+                use ::#crate_name::ValidateContains;
             );
         }
 
         if f.does_not_contain.is_some() {
             does_not_contain = quote!(
-                use validator::ValidateDoesNotContain;
+                use ::#crate_name::ValidateDoesNotContain;
             );
         }
 
         if f.regex.is_some() {
             regex = quote!(
-                use validator::ValidateRegex;
+                use ::#crate_name::ValidateRegex;
             );
         }
     }

--- a/validator_derive/src/utils.rs
+++ b/validator_derive/src/utils.rs
@@ -1,7 +1,38 @@
-use quote::quote;
-use syn::Attribute;
+use quote::{quote, ToTokens};
+use syn::{Attribute, Path};
 
-use crate::{CrateName, ValidateField};
+use crate::ValidateField;
+
+#[derive(Debug, Clone)]
+pub struct CrateName {
+    inner: Path,
+}
+
+impl ToTokens for CrateName {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        self.inner.to_tokens(tokens);
+    }
+}
+
+impl darling::FromMeta for CrateName {
+    fn from_string(value: &str) -> darling::Result<Self> {
+        Path::from_string(value).map(|inner| CrateName { inner })
+    }
+
+    fn from_value(value: &syn::Lit) -> darling::Result<Self> {
+        Path::from_value(value).map(|inner| CrateName { inner })
+    }
+
+    fn from_expr(value: &syn::Expr) -> darling::Result<Self> {
+        Path::from_expr(value).map(|inner| CrateName { inner })
+    }
+}
+
+impl Default for CrateName {
+    fn default() -> Self {
+        CrateName { inner: syn::parse_str("::validator").expect("invalid valid crate name") }
+    }
+}
 
 pub fn quote_message(message: Option<String>) -> proc_macro2::TokenStream {
     if let Some(m) = message {

--- a/validator_derive_tests/tests/compile-fail/wrong_crate_alias.rs
+++ b/validator_derive_tests/tests/compile-fail/wrong_crate_alias.rs
@@ -1,0 +1,16 @@
+use validator as validator_renamed;
+
+mod inner {
+    use super::validator_renamed;
+
+    mod validator {}
+
+    #[derive(validator_renamed::Validate)]
+    #[validate(crate = "validator_other")]
+    struct Test {
+        #[validate(url)]
+        val: String,
+    }
+}
+
+fn main() {}

--- a/validator_derive_tests/tests/compile-fail/wrong_crate_alias.stderr
+++ b/validator_derive_tests/tests/compile-fail/wrong_crate_alias.stderr
@@ -1,0 +1,37 @@
+error[E0432]: unresolved import `validator_other`
+ --> tests/compile-fail/wrong_crate_alias.rs:9:24
+  |
+9 |     #[validate(crate = "validator_other")]
+  |                        ^^^^^^^^^^^^^^^^^ use of undeclared crate or module `validator_other`
+
+error[E0433]: failed to resolve: use of undeclared crate or module `validator_other`
+ --> tests/compile-fail/wrong_crate_alias.rs:9:24
+  |
+9 |     #[validate(crate = "validator_other")]
+  |                        ^^^^^^^^^^^^^^^^^ use of undeclared crate or module `validator_other`
+  |
+help: consider importing one of these items
+  |
+4 +     use crate::validator_renamed::ValidationErrors;
+  |
+4 +     use validator::ValidationErrors;
+  |
+
+error[E0433]: failed to resolve: use of undeclared crate or module `validator_other`
+ --> tests/compile-fail/wrong_crate_alias.rs:9:24
+  |
+9 |     #[validate(crate = "validator_other")]
+  |                        ^^^^^^^^^^^^^^^^^ use of undeclared crate or module `validator_other`
+  |
+help: consider importing one of these items
+  |
+4 +     use crate::validator_renamed::ValidationError;
+  |
+4 +     use validator::ValidationError;
+  |
+
+error[E0433]: failed to resolve: use of undeclared crate or module `validator_other`
+ --> tests/compile-fail/wrong_crate_alias.rs:9:24
+  |
+9 |     #[validate(crate = "validator_other")]
+  |                        ^^^^^^^^^^^^^^^^^ use of undeclared crate or module `validator_other`

--- a/validator_derive_tests/tests/run-pass/crate_alias.rs
+++ b/validator_derive_tests/tests/run-pass/crate_alias.rs
@@ -5,11 +5,23 @@ mod inner {
 
     mod validator {}
 
+    fn validate_fn(_: &str) -> Result<(), validator_renamed::ValidationError> {
+        Ok(())
+    }
+
     #[derive(validator_renamed::Validate)]
     #[validate(crate = "validator_renamed")]
     struct Test {
         #[validate(url)]
-        val: String,
+        url: String,
+        #[validate(email)]
+        email: String,
+        #[validate(length(min = 1, max = 10))]
+        length: String,
+        #[validate(range(min = 1, max = 10))]
+        range: i32,
+        #[validate(custom(function = "validate_fn"))]
+        custom: String,
     }
 }
 

--- a/validator_derive_tests/tests/run-pass/crate_alias.rs
+++ b/validator_derive_tests/tests/run-pass/crate_alias.rs
@@ -1,0 +1,16 @@
+use validator as validator_renamed;
+
+mod inner {
+    use super::validator_renamed;
+
+    mod validator {}
+
+    #[derive(validator_renamed::Validate)]
+    #[validate(crate = "validator_renamed")]
+    struct Test {
+        #[validate(url)]
+        val: String,
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
Currently it's not possible to package up the `validator` crate's derives without requiring users to include the dependency locally (cluttering up their deps list if they don't actually use it).

This PR adds an optional `crate` attribute that overrides all references to the crate with a new name.

```toml
validator_renamed = { package = "validator", version = "0.18", features = ["derive"] }
```

```rust
#[derive(validator_renamed::Validator)]
#[validate(crate = "validator_renamed")]
pub struct MyData {
  // ...
}
```

It also works with paths, e.g.

```rust
#[validate(crate = "some::other::location")]
```