### PR TITLE
Fix incorrect example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ Performs validation on a field with a type that also implements the Validate tra
 Examples:
 
 ```rust
-#[validate]
+#[validate(nested)]
 ```
 
 ### non_control_character


### PR DESCRIPTION
This pull request fixes a minor error in README where `#[validate(nested)]` is written as `#[validate]`.