### PR TITLE
fix: check the name of #[foo] (name only) attributes (#340)

### DIFF
--- a/validator_derive/src/types.rs
+++ b/validator_derive/src/types.rs
@@ -77,7 +77,7 @@ impl ValidateField {
         let field_name = self.ident.clone().expect("Field is not a named field").to_string();
         let field_attrs = &current_field.attrs;
         for attr in field_attrs {
-            if matches!(attr.meta, syn::Meta::Path(_)) {
+            if attr.path().is_ident("validate") && matches!(attr.meta, syn::Meta::Path(_)) {
                 abort!(
                     current_field.span(), "You need to set at least one validator on field `{}`", field_name;
                     note = "If you want nested validation, use `#[validate(nested)]`"


### PR DESCRIPTION
This PR closes #340.

I wanted to add some tests for this, but we need to use another proc macro crate that provides `#[foo]` attributes, so I didn’t. (for example, all serde attributes are `#[serde(...)]`, and there is no `#[serde]`)