### PR TITLE
Add ValidateRegex Implementation For Box, Rc, and Arc

### DIFF
--- a/validator/src/validation/regex.rs
+++ b/validator/src/validation/regex.rs
@@ -102,6 +102,12 @@ impl ValidateRegex for &str {
     }
 }
 
+impl ValidateRegex for str {
+    fn validate_regex(&self, regex: impl AsRegex) -> bool {
+        regex.as_regex().is_match(self)
+    }
+}
+
 impl<T:ValidateRegex> ValidateRegex for Box<T> {
     fn validate_regex(&self, regex: impl AsRegex) -> bool {
         self.as_ref().validate_regex(regex)

--- a/validator/src/validation/regex.rs
+++ b/validator/src/validation/regex.rs
@@ -5,7 +5,6 @@ use std::sync::{Arc, Mutex, OnceLock};
 
 use regex::Regex;
 
-use crate::Validate;
 
 pub trait AsRegex {
     fn as_regex(&self) -> Cow<Regex>;

--- a/validator/src/validation/regex.rs
+++ b/validator/src/validation/regex.rs
@@ -1,8 +1,11 @@
 use std::borrow::Cow;
 use std::cell::OnceCell;
+use std::rc::Rc;
 use std::sync::{Arc, Mutex, OnceLock};
 
 use regex::Regex;
+
+use crate::Validate;
 
 pub trait AsRegex {
     fn as_regex(&self) -> Cow<Regex>;
@@ -98,5 +101,23 @@ impl ValidateRegex for String {
 impl ValidateRegex for &str {
     fn validate_regex(&self, regex: impl AsRegex) -> bool {
         regex.as_regex().is_match(self)
+    }
+}
+
+impl<T:ValidateRegex> ValidateRegex for Box<T> {
+    fn validate_regex(&self, regex: impl AsRegex) -> bool {
+        self.as_ref().validate_regex(regex)
+    }
+}
+
+impl<T:ValidateRegex> ValidateRegex for Rc<T> {
+    fn validate_regex(&self, regex: impl AsRegex) -> bool {
+        self.as_ref().validate_regex(regex)
+    }
+}
+
+impl<T:ValidateRegex> ValidateRegex for Arc<T> {
+    fn validate_regex(&self, regex: impl AsRegex) -> bool {
+        self.as_ref().validate_regex(regex)
     }
 }

--- a/validator/src/validation/regex.rs
+++ b/validator/src/validation/regex.rs
@@ -5,7 +5,6 @@ use std::sync::{Arc, Mutex, OnceLock};
 
 use regex::Regex;
 
-
 pub trait AsRegex {
     fn as_regex(&self) -> Cow<Regex>;
 }


### PR DESCRIPTION
Added a blanket implementation where the inner type T for these container types implements `ValidateRegex`.

These types are sometimes used in place of `String` where the mutability that `String` provides is not necessary.