### PR TITLE
Version changes so Rust-SEC versions can be removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,9 @@
 ## Changelog
 
-## 0.19 (unreleased)
+## 0.19 (2024/11/01)
 
 - Swap to using proc-macro-error-2 instead of proc-macro-error for Syn
 - Bumped MSRV to 1.81 because of error naming changes.
-
-## 0.18.2 (unreleased)
-
 - Add more ValidateRegex impl
 
 

--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@
 Macros 1.1 custom derive to simplify struct validation inspired by [marshmallow](http://marshmallow.readthedocs.io/en/latest/) and
 [Django validators](https://docs.djangoproject.com/en/1.10/ref/validators/).
 
-The minimum supported version is Rust 1.42.
+The minimum supported version is Rust 1.70.
 
 Installation:
 
 ```toml
 [dependencies]
-validator = { version = "0.18", features = ["derive"] }
+validator = { version = "0.19", features = ["derive"] }
 ```
 
 A short example:

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "validator"
-version = "0.18.2"
+version = "0.19.0"
 authors = ["Vincent Prouillet <hello@vincentprouillet.com"]
 license = "MIT"
 description = "Common validation functions (email, url, length, ...) and trait - to be used with `validator_derive`"
@@ -18,7 +18,7 @@ idna = "1"
 serde = "1"
 serde_derive = "1"
 serde_json = "1"
-validator_derive = { version = "0.18", path = "../validator_derive", optional = true }
+validator_derive = { version = "0.19", path = "../validator_derive", optional = true }
 card-validate = { version = "2.3", optional = true }
 unic-ucd-common = { version = "0.9", optional = true }
 indexmap = { version = "2.0.0", features = ["serde"], optional = true }

--- a/validator_derive/Cargo.toml
+++ b/validator_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "validator_derive"
-version = "0.18.2"
+version = "0.19.0"
 authors = ["Vincent Prouillet <hello@vincentprouillet.com"]
 license = "MIT"
 description = "Macros 1.1 implementation of #[derive(Validate)]"

--- a/validator_derive_tests/Cargo.toml
+++ b/validator_derive_tests/Cargo.toml
@@ -10,7 +10,7 @@ test_ui = []
 nightly = []
 
 [dev-dependencies]
-validator = { version = "0.18", path = "../validator", features = [
+validator = { version = "0.19", path = "../validator", features = [
     "card",
     "unic",
     "derive",


### PR DESCRIPTION
I set the date kind of arbitrarily can changed to whatever the planned date is 
Did a couple of things:
1. Closes #351  bumped us to version 0.19.0
2. Closes #346 which to use MSRV as 1.70.0, verified that still works so I bumped the MSRV in readme to 1.70.0.

Does require a release to crates.io