### PR TITLE
feat!: support `Deserialize` for `ValidationErrors`

### DIFF
--- a/validator/src/traits.rs
+++ b/validator/src/traits.rs
@@ -1,4 +1,5 @@
 use crate::types::{ValidationErrors, ValidationErrorsKind};
+use std::borrow::Cow;
 use std::collections::btree_map::BTreeMap;
 use std::collections::HashMap;
 
@@ -32,7 +33,7 @@ macro_rules! impl_validate_list {
                 } else {
                     let err_kind = ValidationErrorsKind::List(vec_err);
                     let errors = ValidationErrors(std::collections::HashMap::from([(
-                        "_tmp_validator",
+                        Cow::Borrowed("_tmp_validator"),
                         err_kind,
                     )]));
                     Err(errors)
@@ -64,8 +65,10 @@ impl<T: Validate, const N: usize> Validate for [T; N] {
             Ok(())
         } else {
             let err_kind = ValidationErrorsKind::List(vec_err);
-            let errors =
-                ValidationErrors(std::collections::HashMap::from([("_tmp_validator", err_kind)]));
+            let errors = ValidationErrors(std::collections::HashMap::from([(
+                Cow::Borrowed("_tmp_validator"),
+                err_kind,
+            )]));
             Err(errors)
         }
     }
@@ -85,7 +88,8 @@ impl<K, V: Validate, S> Validate for &HashMap<K, V, S> {
             Ok(())
         } else {
             let err_kind = ValidationErrorsKind::List(vec_err);
-            let errors = ValidationErrors(HashMap::from([("_tmp_validator", err_kind)]));
+            let errors =
+                ValidationErrors(HashMap::from([(Cow::Borrowed("_tmp_validator"), err_kind)]));
             Err(errors)
         }
     }
@@ -105,7 +109,8 @@ impl<K, V: Validate> Validate for &BTreeMap<K, V> {
             Ok(())
         } else {
             let err_kind = ValidationErrorsKind::List(vec_err);
-            let errors = ValidationErrors(HashMap::from([("_tmp_validator", err_kind)]));
+            let errors =
+                ValidationErrors(HashMap::from([(Cow::Borrowed("_tmp_validator"), err_kind)]));
             Err(errors)
         }
     }

--- a/validator_derive/src/tokens/nested.rs
+++ b/validator_derive/src/tokens/nested.rs
@@ -5,7 +5,7 @@ pub fn nested_tokens(
     field_name_str: &str,
 ) -> proc_macro2::TokenStream {
     quote! {
-        if let std::collections::hash_map::Entry::Vacant(entry) = errors.0.entry(#field_name_str) {
+        if let std::collections::hash_map::Entry::Vacant(entry) = errors.0.entry(::std::borrow::Cow::Borrowed(#field_name_str)) {
             errors.merge_self(#field_name_str, (&#field_name).validate());
         }
     }

--- a/validator_derive_tests/tests/complex.rs
+++ b/validator_derive_tests/tests/complex.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{borrow::Cow, collections::HashMap};
 
 use once_cell::sync::Lazy;
 use regex::Regex;
@@ -213,7 +213,7 @@ fn test_works_with_none_values() {
 #[allow(dead_code)]
 fn unwrap_map<F>(errors: &ValidationErrors, f: F)
 where
-    F: FnOnce(HashMap<&'static str, ValidationErrorsKind>),
+    F: FnOnce(HashMap<Cow<'static, str>, ValidationErrorsKind>),
 {
     let errors = errors.clone();
     f(errors.errors().clone());

--- a/validator_derive_tests/tests/custom.rs
+++ b/validator_derive_tests/tests/custom.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{borrow::Cow, collections::HashMap};
 
 use validator::{Validate, ValidationError, ValidationErrors, ValidationErrorsKind};
 
@@ -171,9 +171,9 @@ fn custom_fn_on_optional_types_work() {
     assert_eq!(
         t.validate(),
         Err(ValidationErrors(HashMap::from_iter([
-            ("plain", error_kind.clone()),
-            ("option", error_kind.clone()),
-            ("option_option", error_kind),
+            (Cow::Borrowed("plain"), error_kind.clone()),
+            (Cow::Borrowed("option"), error_kind.clone()),
+            (Cow::Borrowed("option_option"), error_kind),
         ])))
     );
 }

--- a/validator_derive_tests/tests/nested.rs
+++ b/validator_derive_tests/tests/nested.rs
@@ -72,10 +72,10 @@ fn fails_nested_validation_multiple_members() {
     assert_eq!(
         root.validate(),
         Err(ValidationErrors(HashMap::from_iter([(
-            "a",
+            Cow::Borrowed("a"),
             ValidationErrorsKind::Struct(Box::new(ValidationErrors(HashMap::from_iter([
-                ("value1", error_kind.clone()),
-                ("value2", error_kind),
+                (Cow::Borrowed("value1"), error_kind.clone()),
+                (Cow::Borrowed("value2"), error_kind),
             ]))))
         )])))
     );
@@ -905,7 +905,7 @@ fn test_field_validations_evaluated_after_nested_validations_fails() {
 #[allow(dead_code)]
 fn unwrap_map<F>(errors: &ValidationErrors, f: F)
 where
-    F: FnOnce(HashMap<&'static str, ValidationErrorsKind>),
+    F: FnOnce(HashMap<Cow<'static, str>, ValidationErrorsKind>),
 {
     let errors = errors.clone();
     f(errors.errors().clone());


### PR DESCRIPTION
Use `Cow<'static, str>` as suggested in https://github.com/Keats/validator/issues/358#issuecomment-2491283345.

Fixes #358 