### PR TITLE
Remove dependency on unic-ucd-common by using std::char::is_control

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,8 @@ jobs:
         run: |
           cargo build --no-default-features
           cargo test --no-default-features
-          cargo build --features unic --features derive --features card
-          cargo test  --features unic --features derive --features card
+          cargo build --features derive --features card
+          cargo test --features derive --features card
   test_validator-nightly:
     name: Continuous integration
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -335,7 +335,6 @@ Examples:
 
 ### non_control_character
 Tests whether the String has any utf-8 control characters, fails validation if it does.
-To use this validator, you must enable the `unic` feature for the `validator` crate.
 This validator doesn't take any arguments: `#[validate(non_control_character)]`;
 
 ### required

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -21,11 +21,9 @@ serde_derive = "1"
 serde_json = "1"
 validator_derive = { version = "0.20", path = "../validator_derive", optional = true }
 card-validate = { version = "2.3", optional = true }
-unic-ucd-common = { version = "0.9", optional = true }
 indexmap = { version = "2.0.0", features = ["serde"], optional = true }
 
 [features]
 card = ["card-validate"]
-unic = ["unic-ucd-common"]
 derive = ["validator_derive"]
 derive_nightly_features = ["derive","validator_derive/nightly_features"]

--- a/validator/src/lib.rs
+++ b/validator/src/lib.rs
@@ -47,7 +47,7 @@
 //! | `custom`                |                                                       |
 //! | `regex`                 |                                                       |
 //! | `credit_card`           | (Requires the feature `card` to be enabled)           |
-//! | `non_control_character` | (Required the feature `unic` to be enabled)           |
+//! | `non_control_character` |                                                       |
 //! | `required`              |                                                       |
 //!
 //! [Checkout the project README of an in-depth usage description with examples.](https://github.com/Keats/validator/blob/master/README.md)
@@ -73,7 +73,6 @@ pub use validation::email::ValidateEmail;
 pub use validation::ip::ValidateIp;
 pub use validation::length::ValidateLength;
 pub use validation::must_match::validate_must_match;
-#[cfg(feature = "unic")]
 pub use validation::non_control_character::ValidateNonControlCharacter;
 pub use validation::range::ValidateRange;
 pub use validation::regex::{AsRegex, ValidateRegex};

--- a/validator/src/validation/mod.rs
+++ b/validator/src/validation/mod.rs
@@ -7,7 +7,6 @@ pub mod ip;
 pub mod length;
 pub mod must_match;
 // pub mod nested;
-#[cfg(feature = "unic")]
 pub mod non_control_character;
 pub mod range;
 pub mod regex;

--- a/validator/src/validation/non_control_character.rs
+++ b/validator/src/validation/non_control_character.rs
@@ -1,9 +1,6 @@
-#[cfg(feature = "unic")]
-use unic_ucd_common::control;
-
 pub trait ValidateNonControlCharacter {
     fn validate_non_control_character(&self) -> bool {
-        self.as_non_control_character_iterator().all(|code| !control::is_control(code))
+        self.as_non_control_character_iterator().all(|code| !code.is_control())
     }
 
     fn as_non_control_character_iterator(&self) -> Box<dyn Iterator<Item = char> + '_>;
@@ -16,7 +13,6 @@ impl<T: AsRef<str>> ValidateNonControlCharacter for T {
 }
 
 #[cfg(test)]
-#[cfg(feature = "unic")]
 mod tests {
     use super::ValidateNonControlCharacter;
     use std::borrow::Cow;

--- a/validator_derive_tests/Cargo.toml
+++ b/validator_derive_tests/Cargo.toml
@@ -13,7 +13,6 @@ nightly = []
 [dev-dependencies]
 validator = { version = "0.20", path = "../validator", features = [
     "card",
-    "unic",
     "derive",
     "indexmap",
 ] }


### PR DESCRIPTION
Checking whether a character is a control character is already present in the `std`, so no external dependency is required and the `unic` feature no longer needs to exist (or at least is built-in).