### PR TITLE
Update regex example

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ static RE_TWO_CHARS: Lazy<Regex> = Lazy::new(|| {
     Regex::new(r"[a-z]{2}$").unwrap()
 });
 
-#[validate(regex(path = *RE_TWO_CHARS)]
+#[validate(regex(path = *RE_TWO_CHARS))]
 ```
 
 ### credit\_card

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ Tests whether the string matches the regex given. `regex` takes
 Examples:
 
 ```rust
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
 
 static RE_TWO_CHARS: Lazy<Regex> = Lazy::new(|| {
     Regex::new(r"[a-z]{2}$").unwrap()


### PR DESCRIPTION
We can now use LazyLock from the Rust std library. There's also an error in the Regex example, which also has been fixed.