### PR TITLE
Add convenience with_error ValidationErrors

### DIFF
--- a/validator/src/types.rs
+++ b/validator/src/types.rs
@@ -162,7 +162,13 @@ impl ValidationErrors {
             })
             .collect::<HashMap<_, _>>()
     }
+    /// Add a field validation error to the struct, returning self
+    pub fn with_error(mut self, field: &'static str, error: ValidationError) -> ValidationErrors {
+        self.add(field, error);
+        self
+    }
 
+    /// Add a field validation error to the struct
     pub fn add(&mut self, field: &'static str, error: ValidationError) {
         if let ValidationErrorsKind::Field(ref mut vec) = self
             .0


### PR DESCRIPTION
This PR simply adds a convenience method so you can chain when adding errors to `ValidationErrors`. It just calls `add` and returns `self`.