### PR TITLE
Feature flag out the external dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,12 +155,12 @@ validation functions and types.
 ## Validators
 The crate comes with some built-in validators and you can have several validators for a given field.
 
-### email
+### email (optional)
 Tests whether the String is a valid email according to the HTML5 regex, which means it will mark
 some esoteric emails as invalid that won't be valid in a `email` input as well.
 This validator doesn't take any arguments: `#[validate(email)]`.
 
-### url
+### url (optional)
 Tests whether the String is a valid URL.
 This validator doesn't take any arguments: `#[validate(url)]`;
 
@@ -244,7 +244,7 @@ Examples:
 #[validate(does_not_contain(pattern = "gmail"))]
 ```
 
-### regex
+### regex (optional)
 Tests whether the string matches the regex given. `regex` takes
 1 string argument: the path to a static Regex instance.
 
@@ -402,5 +402,10 @@ For example, the following attributes all work:
 ```
 
 ## Features
+By default, the `email`, `url` and `regex` features are enabled to provide compatibility with versions < 0.21.0.s
+
 `derive` - This allows for the use of the derive macro.
 `derive_nightly_features` - This imports both derive as well as proc-macro-error2 nightly features. This allows proc-macro-error2 to emit extra nightly warnings.
+`email` - Allows for email validation, pulls in idna and turns on `regex` feature flag.
+`url` - Allows for url validation, pulls in url optional dependency.
+`regex` - Allows for regex validation, pulling in regex optional dependency.

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -12,9 +12,9 @@ readme = "../README.md"
 rust-version = { workspace = true }
 
 [dependencies]
-url = "2"
-regex = { version = "1", default-features = false, features = ["std"] }
-idna = "1"
+url = { version = "2", optional = true }
+regex = { version = "1", default-features = false, features = ["std"], optional = true }
+idna = { version = "1", optional = true }
 serde = "1"
 serde_derive = "1"
 serde_json = "1"
@@ -23,6 +23,10 @@ card-validate = { version = "2.3", optional = true }
 indexmap = { version = "2.0.0", features = ["serde"], optional = true }
 
 [features]
+default = ["regex", "url", "email"]
 card = ["card-validate"]
 derive = ["validator_derive"]
 derive_nightly_features = ["derive", "validator_derive/nightly_features"]
+regex = ["dep:regex"]
+url = ["dep:url"]
+email = ["dep:idna", "regex"]

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "validator"
-version = "0.20.0"
+version = "0.21.0"
 authors = ["Vincent Prouillet <hello@vincentprouillet.com"]
 license = "MIT"
 description = "Common validation functions (email, url, length, ...) and trait - to be used with `validator_derive`"

--- a/validator/src/lib.rs
+++ b/validator/src/lib.rs
@@ -69,14 +69,17 @@ mod validation;
 pub use validation::cards::ValidateCreditCard;
 pub use validation::contains::ValidateContains;
 pub use validation::does_not_contain::ValidateDoesNotContain;
+#[cfg(feature = "email")]
 pub use validation::email::ValidateEmail;
 pub use validation::ip::ValidateIp;
 pub use validation::length::ValidateLength;
 pub use validation::must_match::validate_must_match;
 pub use validation::non_control_character::ValidateNonControlCharacter;
 pub use validation::range::ValidateRange;
+#[cfg(feature = "regex")]
 pub use validation::regex::{AsRegex, ValidateRegex};
 pub use validation::required::ValidateRequired;
+#[cfg(feature = "url")]
 pub use validation::urls::ValidateUrl;
 
 pub use traits::{Validate, ValidateArgs};

--- a/validator/src/validation/mod.rs
+++ b/validator/src/validation/mod.rs
@@ -2,6 +2,7 @@
 pub mod cards;
 pub mod contains;
 pub mod does_not_contain;
+#[cfg(feature = "email")]
 pub mod email;
 pub mod ip;
 pub mod length;
@@ -9,6 +10,8 @@ pub mod must_match;
 // pub mod nested;
 pub mod non_control_character;
 pub mod range;
+#[cfg(feature = "regex")]
 pub mod regex;
 pub mod required;
+#[cfg(feature = "url")]
 pub mod urls;

--- a/validator_derive/Cargo.toml
+++ b/validator_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "validator_derive"
-version = "0.20.0"
+version = "0.21.0"
 authors = ["Vincent Prouillet <hello@vincentprouillet.com"]
 license = "MIT"
 description = "Macros 1.1 implementation of #[derive(Validate)]"


### PR DESCRIPTION
The rationale for this change is that there are cases where people would like to use the general validation infrastructure, as well as the validation derive macros for simple data types, but do not want to pull in these extra dependencies to their dependency graph. The remaining validators that are not affected by this PR affect built-in types and as such are always enabled.

By enabling the new feature flags by default, this is **not** a breaking change, unless the downstream user explicitly set default-features = false.