### PR TITLE
Fix email validation to reject TLD-only domains like user@com

### DIFF
--- a/validator_derive_tests/tests/email.rs
+++ b/validator_derive_tests/tests/email.rs
@@ -100,3 +100,24 @@ fn can_validate_custom_impl_for_email() {
     assert!(valid.validate().is_ok());
     assert!(invalid.validate().is_err());
 }
+
+#[test]
+fn top_level_domain_only_fails_validation() {
+    #[derive(Debug, Validate)]
+    struct TestStruct {
+        #[validate(email)]
+        val: String,
+    }
+
+    let s = TestStruct { val: "user@com".to_string() };
+    let res = s.validate();
+    assert!(res.is_err());
+
+    let err = res.unwrap_err();
+    let errs = err.field_errors();
+
+    assert!(errs.contains_key("val"));
+    assert_eq!(errs["val"].len(), 1);
+    assert_eq!(errs["val"][0].code, "email");
+    assert_eq!(errs["val"][0].params["value"], "user@com");
+}


### PR DESCRIPTION
This pull request enhances the email validation logic in `validator/src/validation/email.rs` to ensure stricter compliance with domain validation rules. It also updates the corresponding test cases to reflect these changes and adds new tests to cover edge cases.

### Email Validation Logic Updates:

* Modified `validate_domain_part` to reject email addresses with top-level domains (e.g., `user@com`) by requiring at least one dot in the domain part. This ensures stricter validation of domain structures.

### Test Case Updates:

* Updated an existing test case to mark `abc@bar` as invalid, aligning with the stricter domain validation rules.
* Added a new test case `test_user_at_com_fails` to validate that `user@com` is correctly identified as an invalid email address.
* Introduced a test in `validator_derive_tests/tests/email.rs` to ensure that custom implementations for email validation also reject top-level domain-only email addresses. This includes detailed error assertions to verify the validation logic.