### PR TITLE
Update to rust 1.86, fix ci, introduce clippy and fmt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable # actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: ${{ env.MSRV }}
+          components: clippy,rustfmt
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v2
       - name: Build System Info
@@ -26,6 +27,11 @@ jobs:
           cargo test --no-default-features
           cargo build --features derive --features card
           cargo test --features derive --features card
+      - name: Format check
+        run: cargo fmt --check
+      - name: Run Clippy
+        run: cargo clippy --all-targets --features derive --features card -- -D warnings
+
   test_validator-nightly:
     name: Continuous integration
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     name: Continuous integration
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Extract Rust version from Cargo.toml
         run: |
           MSRV=$(sed -n 's/^rust-version = "\([^"]*\)"/\1/p' Cargo.toml)
@@ -34,7 +34,7 @@ jobs:
         include:
           - rust: nightly
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,4 +3,4 @@ resolver = "2"
 members = ["validator", "validator_derive", "validator_derive_tests"]
 
 [workspace.package]
-rust-version = "1.81"
+rust-version = "1.86"

--- a/validator/src/validation/cards.rs
+++ b/validator/src/validation/cards.rs
@@ -9,11 +9,11 @@ pub trait ValidateCreditCard {
         CardValidate::from(&card_string).is_ok()
     }
 
-    fn as_credit_card_string(&self) -> Cow<str>;
+    fn as_credit_card_string(&self) -> Cow<'_, str>;
 }
 
 impl<T: AsRef<str>> ValidateCreditCard for T {
-    fn as_credit_card_string(&self) -> Cow<str> {
+    fn as_credit_card_string(&self) -> Cow<'_, str> {
         Cow::from(self.as_ref())
     }
 }

--- a/validator/src/validation/email.rs
+++ b/validator/src/validation/email.rs
@@ -77,20 +77,20 @@ pub trait ValidateEmail {
         true
     }
 
-    fn as_email_string(&self) -> Option<Cow<str>>;
+    fn as_email_string(&self) -> Option<Cow<'_, str>>;
 }
 
 impl<T> ValidateEmail for &T
 where
     T: ValidateEmail,
 {
-    fn as_email_string(&self) -> Option<Cow<str>> {
+    fn as_email_string(&self) -> Option<Cow<'_, str>> {
         T::as_email_string(self)
     }
 }
 
 impl ValidateEmail for String {
-    fn as_email_string(&self) -> Option<Cow<str>> {
+    fn as_email_string(&self) -> Option<Cow<'_, str>> {
         Some(Cow::from(self))
     }
 }
@@ -99,7 +99,7 @@ impl<T> ValidateEmail for Option<T>
 where
     T: ValidateEmail,
 {
-    fn as_email_string(&self) -> Option<Cow<str>> {
+    fn as_email_string(&self) -> Option<Cow<'_, str>> {
         let Some(u) = self else {
             return None;
         };

--- a/validator/src/validation/regex.rs
+++ b/validator/src/validation/regex.rs
@@ -6,11 +6,11 @@ use std::sync::{Arc, LazyLock, Mutex, OnceLock};
 use regex::Regex;
 
 pub trait AsRegex {
-    fn as_regex(&self) -> Cow<Regex>;
+    fn as_regex(&self) -> Cow<'_, Regex>;
 }
 
 impl AsRegex for Regex {
-    fn as_regex(&self) -> Cow<Regex> {
+    fn as_regex(&self) -> Cow<'_, Regex> {
         Cow::Borrowed(self)
     }
 }
@@ -19,43 +19,43 @@ impl<T> AsRegex for &T
 where
     T: AsRegex,
 {
-    fn as_regex(&self) -> Cow<Regex> {
+    fn as_regex(&self) -> Cow<'_, Regex> {
         T::as_regex(self)
     }
 }
 
 impl AsRegex for &OnceLock<Regex> {
-    fn as_regex(&self) -> Cow<Regex> {
+    fn as_regex(&self) -> Cow<'_, Regex> {
         Cow::Borrowed(self.get().unwrap())
     }
 }
 
 impl AsRegex for &Mutex<OnceCell<Regex>> {
-    fn as_regex(&self) -> Cow<Regex> {
+    fn as_regex(&self) -> Cow<'_, Regex> {
         Cow::Owned(self.lock().unwrap().get().unwrap().clone())
     }
 }
 
 impl AsRegex for &Mutex<OnceLock<Regex>> {
-    fn as_regex(&self) -> Cow<Regex> {
+    fn as_regex(&self) -> Cow<'_, Regex> {
         Cow::Owned(self.lock().unwrap().get().unwrap().clone())
     }
 }
 
 impl AsRegex for &Arc<Mutex<OnceCell<Regex>>> {
-    fn as_regex(&self) -> Cow<Regex> {
+    fn as_regex(&self) -> Cow<'_, Regex> {
         Cow::Owned(self.lock().unwrap().get().unwrap().clone())
     }
 }
 
 impl AsRegex for &Arc<Mutex<OnceLock<Regex>>> {
-    fn as_regex(&self) -> Cow<Regex> {
+    fn as_regex(&self) -> Cow<'_, Regex> {
         Cow::Owned(self.lock().unwrap().get().unwrap().clone())
     }
 }
 
 impl AsRegex for LazyLock<Regex> {
-    fn as_regex(&self) -> Cow<Regex> {
+    fn as_regex(&self) -> Cow<'_, Regex> {
         Cow::Borrowed(self)
     }
 }

--- a/validator/src/validation/urls.rs
+++ b/validator/src/validation/urls.rs
@@ -16,7 +16,7 @@ pub trait ValidateUrl {
         }
     }
 
-    fn as_url_string(&self) -> Option<Cow<str>>;
+    fn as_url_string(&self) -> Option<Cow<'_, str>>;
 }
 
 macro_rules! validate_type_that_derefs {
@@ -25,7 +25,7 @@ macro_rules! validate_type_that_derefs {
         where
             T: ValidateUrl,
         {
-            fn as_url_string(&self) -> Option<Cow<str>> {
+            fn as_url_string(&self) -> Option<Cow<'_, str>> {
                 T::as_url_string(self)
             }
         }
@@ -42,7 +42,7 @@ validate_type_that_derefs!(RefMut<'_, T>);
 macro_rules! validate_type_of_str {
     ($type_:ty) => {
         impl ValidateUrl for $type_ {
-            fn as_url_string(&self) -> Option<Cow<str>> {
+            fn as_url_string(&self) -> Option<Cow<'_, str>> {
                 Some(Cow::Borrowed(self))
             }
         }
@@ -57,7 +57,7 @@ impl<T> ValidateUrl for Option<T>
 where
     T: ValidateUrl,
 {
-    fn as_url_string(&self) -> Option<Cow<str>> {
+    fn as_url_string(&self) -> Option<Cow<'_, str>> {
         let Some(u) = self else {
             return None;
         };

--- a/validator_derive/src/lib.rs
+++ b/validator_derive/src/lib.rs
@@ -280,8 +280,7 @@ impl ValidationData {
         }
 
         if let Data::Struct(fields) = &self.data {
-            let original_fields: Vec<&Field> =
-                fields.fields.iter().map(|f| &f.original).collect();
+            let original_fields: Vec<&Field> = fields.fields.iter().map(|f| &f.original).collect();
             for f in &fields.fields {
                 f.parsed.validate(&self.ident, &original_fields, &f.original);
             }

--- a/validator_derive/src/types.rs
+++ b/validator_derive/src/types.rs
@@ -153,12 +153,11 @@ impl ValidateField {
     pub fn number_options(&self) -> u8 {
         fn find_option(mut count: u8, ty: &syn::Type) -> u8 {
             if let syn::Type::Path(p) = ty {
-                let idents_of_path =
-                    p.path.segments.iter().fold(String::new(), |mut acc, v| {
-                        acc.push_str(&v.ident.to_string());
-                        acc.push('|');
-                        acc
-                    });
+                let idents_of_path = p.path.segments.iter().fold(String::new(), |mut acc, v| {
+                    acc.push_str(&v.ident.to_string());
+                    acc.push('|');
+                    acc
+                });
 
                 if OPTIONS_TYPE.contains(&idents_of_path.as_str()) {
                     count += 1;

--- a/validator_derive_tests/tests/compile-fail/wrong_crate_alias.stderr
+++ b/validator_derive_tests/tests/compile-fail/wrong_crate_alias.stderr
@@ -2,14 +2,17 @@ error[E0432]: unresolved import `validator_other`
  --> tests/compile-fail/wrong_crate_alias.rs:9:24
   |
 9 |     #[validate(crate = "validator_other")]
-  |                        ^^^^^^^^^^^^^^^^^ use of undeclared crate or module `validator_other`
+  |                        ^^^^^^^^^^^^^^^^^ use of unresolved module or unlinked crate `validator_other`
+  |
+  = help: if you wanted to use a crate named `validator_other`, use `cargo add validator_other` to add it to your `Cargo.toml`
 
-error[E0433]: failed to resolve: use of undeclared crate or module `validator_other`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `validator_other`
  --> tests/compile-fail/wrong_crate_alias.rs:9:24
   |
 9 |     #[validate(crate = "validator_other")]
-  |                        ^^^^^^^^^^^^^^^^^ use of undeclared crate or module `validator_other`
+  |                        ^^^^^^^^^^^^^^^^^ use of unresolved module or unlinked crate `validator_other`
   |
+  = help: if you wanted to use a crate named `validator_other`, use `cargo add validator_other` to add it to your `Cargo.toml`
 help: consider importing one of these structs
   |
 4 +     use crate::validator_renamed::ValidationErrors;
@@ -17,12 +20,13 @@ help: consider importing one of these structs
 4 +     use validator::ValidationErrors;
   |
 
-error[E0433]: failed to resolve: use of undeclared crate or module `validator_other`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `validator_other`
  --> tests/compile-fail/wrong_crate_alias.rs:9:24
   |
 9 |     #[validate(crate = "validator_other")]
-  |                        ^^^^^^^^^^^^^^^^^ use of undeclared crate or module `validator_other`
+  |                        ^^^^^^^^^^^^^^^^^ use of unresolved module or unlinked crate `validator_other`
   |
+  = help: if you wanted to use a crate named `validator_other`, use `cargo add validator_other` to add it to your `Cargo.toml`
 help: consider importing one of these structs
   |
 4 +     use crate::validator_renamed::ValidationError;
@@ -30,8 +34,10 @@ help: consider importing one of these structs
 4 +     use validator::ValidationError;
   |
 
-error[E0433]: failed to resolve: use of undeclared crate or module `validator_other`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `validator_other`
  --> tests/compile-fail/wrong_crate_alias.rs:9:24
   |
 9 |     #[validate(crate = "validator_other")]
-  |                        ^^^^^^^^^^^^^^^^^ use of undeclared crate or module `validator_other`
+  |                        ^^^^^^^^^^^^^^^^^ use of unresolved module or unlinked crate `validator_other`
+  |
+  = help: if you wanted to use a crate named `validator_other`, use `cargo add validator_other` to add it to your `Cargo.toml`

--- a/validator_derive_tests/tests/credit_card.rs
+++ b/validator_derive_tests/tests/credit_card.rs
@@ -85,7 +85,7 @@ fn can_validate_custom_impl_for_credit_card() {
     }
 
     impl validator::ValidateCreditCard for CustomCreditCard {
-        fn as_credit_card_string(&self) -> Cow<str> {
+        fn as_credit_card_string(&self) -> Cow<'_, str> {
             Cow::from(format!("{}{}{}", &self.bin, &self.ian, &self.check,))
         }
     }

--- a/validator_derive_tests/tests/ip.rs
+++ b/validator_derive_tests/tests/ip.rs
@@ -1,6 +1,6 @@
 use serde::Serialize;
+use std::fmt;
 use validator::Validate;
-
 #[test]
 fn can_validate_ipv4() {
     #[derive(Validate)]
@@ -170,9 +170,9 @@ fn can_validate_custom_impl_for_ip() {
         val: CustomIp,
     }
 
-    impl ToString for CustomIp {
-        fn to_string(&self) -> String {
-            format!("{}.{}.{}.{}", self.a, self.b, self.c, self.d)
+    impl fmt::Display for CustomIp {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "{}.{}.{}.{}", self.a, self.b, self.c, self.d)
         }
     }
 

--- a/validator_derive_tests/tests/range.rs
+++ b/validator_derive_tests/tests/range.rs
@@ -6,7 +6,7 @@ const MIN_CONST: usize = 0;
 // Loose floating point comparison using EPSILON error bound
 macro_rules! assert_float {
     ($e1:expr, $e2:expr) => {
-        assert!(($e2 - $e1).abs() < std::f64::EPSILON);
+        assert!(($e2 - $e1).abs() < f64::EPSILON);
     };
 }
 


### PR DESCRIPTION
Since the ci was not working when reviewing a PR, I tried to make it working again.

Root cause:
indexmap >=2.12 goes for hashbrown 0.17 which needs rust 1.86
idna -> idna_adapter -> icu... also needs rust 1.86

I see no other way then to go along with it. This also obsolets #385.

I also introduced clippy and rustfmt check since i noticed wrong formatting and linter warings. I also fixed them they where only minor changes.