### PR TITLE
Replace proc-macro-error2 with proc-macro-error3

### DIFF
--- a/validator_derive/Cargo.toml
+++ b/validator_derive/Cargo.toml
@@ -18,8 +18,8 @@ proc-macro = true
 syn = "2"
 quote = "1"
 proc-macro2 = "1"
-proc-macro-error2 = "2"
+proc-macro-error3 = "3"
 darling = { version = "0.21", features = ["suggestions"] }
 
 [features]
-nightly_features = ["proc-macro-error2/nightly"]
+nightly_features = ["proc-macro-error3/nightly"]

--- a/validator_derive/src/lib.rs
+++ b/validator_derive/src/lib.rs
@@ -1,7 +1,7 @@
 use darling::ast::Data;
 use darling::util::{Override, WithOriginal};
 use darling::FromDeriveInput;
-use proc_macro_error2::{abort, proc_macro_error};
+use proc_macro_error3::{abort, proc_macro_error};
 use quote::{quote, ToTokens};
 use syn::{parse_macro_input, DeriveInput, Field, GenericParam, Path, PathArguments};
 

--- a/validator_derive/src/types.rs
+++ b/validator_derive/src/types.rs
@@ -3,7 +3,7 @@ use std::sync::LazyLock;
 use darling::util::Override;
 use darling::{FromField, FromMeta};
 
-use proc_macro_error2::abort;
+use proc_macro_error3::abort;
 use quote::quote;
 use syn::spanned::Spanned;
 use syn::{Expr, Field, Ident, Path};


### PR DESCRIPTION
proc-macro-error2 is unmaintained. 
proc-macro-error3 is a maintained fork with the same API and several bug fixes including a future-incompatibility warning from rustc.