### PR TITLE
 cargo: make idna-related dependencies optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Add `unicode_email` and `url` features (both on by default) so the `idna` dependency and its ICU
   tables can be dropped with `default-features = false`
+- Add `email` and `regex` features (both on by default) so the `regex` dependency can be dropped
+  with `default-features = false`
 
 ## 0.21.0 (2026/07/09)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Changelog
 
+## Unreleased
+
+- Add `unicode_email` and `url` features (both on by default) so the `idna` dependency and its ICU
+  tables can be dropped with `default-features = false`
+
 ## 0.21.0 (2026/07/09)
 
 - Replace dep proc-macro-error2 with proc-macro-error3

--- a/README.md
+++ b/README.md
@@ -160,9 +160,14 @@ Tests whether the String is a valid email according to the HTML5 regex, which me
 some esoteric emails as invalid that won't be valid in a `email` input as well.
 This validator doesn't take any arguments: `#[validate(email)]`.
 
+Internationalized domain names (eg `test@उदाहरण.परीक्षा`) require the `unicode_email` feature,
+which is enabled by default. Without it, such addresses are rejected.
+
 ### url
 Tests whether the String is a valid URL.
 This validator doesn't take any arguments: `#[validate(url)]`;
+
+Requires the `url` feature, which is enabled by default.
 
 ### length
 Tests whether a String or a Vec match the length requirement given. `length` has 3 integer arguments:
@@ -404,3 +409,6 @@ For example, the following attributes all work:
 ## Features
 `derive` - This allows for the use of the derive macro.
 `derive_nightly_features` - This imports both derive as well as proc-macro-error2 nightly features. This allows proc-macro-error2 to emit extra nightly warnings.
+`card` - Enables the `credit_card` validator.
+`unicode_email` (default) - Pulls in `idna` so email validation accepts internationalized domain names.
+`url` (default) - Enables the `url` validator, pulling in the `url` crate.

--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ Tests whether the String is a valid email according to the HTML5 regex, which me
 some esoteric emails as invalid that won't be valid in a `email` input as well.
 This validator doesn't take any arguments: `#[validate(email)]`.
 
+Requires the `email` feature, which is enabled by default and pulls in the `regex` crate.
+
 Internationalized domain names (eg `test@उदाहरण.परीक्षा`) require the `unicode_email` feature,
 which is enabled by default. Without it, such addresses are rejected.
 
@@ -252,6 +254,8 @@ Examples:
 ### regex
 Tests whether the string matches the regex given. `regex` takes
 1 string argument: the path to a static Regex instance.
+
+Requires the `regex` feature, which is enabled by default.
 
 Examples:
 
@@ -410,5 +414,7 @@ For example, the following attributes all work:
 `derive` - This allows for the use of the derive macro.
 `derive_nightly_features` - This imports both derive as well as proc-macro-error2 nightly features. This allows proc-macro-error2 to emit extra nightly warnings.
 `card` - Enables the `credit_card` validator.
-`unicode_email` (default) - Pulls in `idna` so email validation accepts internationalized domain names.
+`email` (default) - Enables the `email` validator, pulling in the `regex` crate.
+`regex` (default) - Enables the `regex` validator, pulling in the `regex` crate.
+`unicode_email` (default) - Pulls in `idna` so email validation accepts internationalized domain names. Implies `email`.
 `url` (default) - Enables the `url` validator, pulling in the `url` crate.

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -13,7 +13,7 @@ rust-version = { workspace = true }
 
 [dependencies]
 url = { version = "2", optional = true }
-regex = { version = "1", default-features = false, features = ["std"] }
+regex = { version = "1", default-features = false, features = ["std"], optional = true }
 idna = { version = "1", optional = true }
 serde = "1"
 serde_derive = "1"
@@ -23,9 +23,11 @@ card-validate = { version = "2.3", optional = true }
 indexmap = { version = "2.0.0", features = ["serde"], optional = true }
 
 [features]
-default = ["unicode_email", "url"]
+default = ["email", "regex", "unicode_email", "url"]
 card = ["card-validate"]
 derive = ["validator_derive"]
 derive_nightly_features = ["derive", "validator_derive/nightly_features"]
-unicode_email = ["dep:idna"]
+email = ["dep:regex"]
+regex = ["dep:regex"]
+unicode_email = ["email", "dep:idna"]
 url = ["dep:url"]

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -12,9 +12,9 @@ readme = "../README.md"
 rust-version = { workspace = true }
 
 [dependencies]
-url = "2"
+url = { version = "2", optional = true }
 regex = { version = "1", default-features = false, features = ["std"] }
-idna = "1"
+idna = { version = "1", optional = true }
 serde = "1"
 serde_derive = "1"
 serde_json = "1"
@@ -23,6 +23,9 @@ card-validate = { version = "2.3", optional = true }
 indexmap = { version = "2.0.0", features = ["serde"], optional = true }
 
 [features]
+default = ["unicode_email", "url"]
 card = ["card-validate"]
 derive = ["validator_derive"]
 derive_nightly_features = ["derive", "validator_derive/nightly_features"]
+unicode_email = ["dep:idna"]
+url = ["dep:url"]

--- a/validator/src/lib.rs
+++ b/validator/src/lib.rs
@@ -37,8 +37,8 @@
 //! # Available Validations:
 //! | Validation              | Notes                                                 |
 //! | ----------------------- | ----------------------------------------------------- |
-//! | `email`                 |                                                       |
-//! | `url`                   |                                                       |
+//! | `email`                 | (IDN domains require the feature `unicode_email`)     |
+//! | `url`                   | (Requires the feature `url` to be enabled)            |
 //! | `length`                |                                                       |
 //! | `range`                 |                                                       |
 //! | `must_match`            |                                                       |
@@ -77,6 +77,7 @@ pub use validation::non_control_character::ValidateNonControlCharacter;
 pub use validation::range::ValidateRange;
 pub use validation::regex::{AsRegex, ValidateRegex};
 pub use validation::required::ValidateRequired;
+#[cfg(feature = "url")]
 pub use validation::urls::ValidateUrl;
 
 pub use traits::{Validate, ValidateArgs};

--- a/validator/src/lib.rs
+++ b/validator/src/lib.rs
@@ -37,7 +37,7 @@
 //! # Available Validations:
 //! | Validation              | Notes                                                 |
 //! | ----------------------- | ----------------------------------------------------- |
-//! | `email`                 | (IDN domains require the feature `unicode_email`)     |
+//! | `email`                 | (Requires the feature `email`; IDN domains also need `unicode_email`) |
 //! | `url`                   | (Requires the feature `url` to be enabled)            |
 //! | `length`                |                                                       |
 //! | `range`                 |                                                       |
@@ -45,7 +45,7 @@
 //! | `contains`              |                                                       |
 //! | `does_not_contain`      |                                                       |
 //! | `custom`                |                                                       |
-//! | `regex`                 |                                                       |
+//! | `regex`                 | (Requires the feature `regex` to be enabled)          |
 //! | `credit_card`           | (Requires the feature `card` to be enabled)           |
 //! | `non_control_character` |                                                       |
 //! | `required`              |                                                       |
@@ -69,12 +69,14 @@ mod validation;
 pub use validation::cards::ValidateCreditCard;
 pub use validation::contains::ValidateContains;
 pub use validation::does_not_contain::ValidateDoesNotContain;
+#[cfg(feature = "email")]
 pub use validation::email::ValidateEmail;
 pub use validation::ip::ValidateIp;
 pub use validation::length::ValidateLength;
 pub use validation::must_match::validate_must_match;
 pub use validation::non_control_character::ValidateNonControlCharacter;
 pub use validation::range::ValidateRange;
+#[cfg(feature = "regex")]
 pub use validation::regex::{AsRegex, ValidateRegex};
 pub use validation::required::ValidateRequired;
 #[cfg(feature = "url")]

--- a/validator/src/validation/email.rs
+++ b/validator/src/validation/email.rs
@@ -1,4 +1,3 @@
-use idna::domain_to_ascii;
 use regex::Regex;
 use std::{borrow::Cow, sync::LazyLock};
 
@@ -35,6 +34,24 @@ fn validate_domain_part(domain_part: &str) -> bool {
     }
 }
 
+/// Punycodes an [IDN](https://en.wikipedia.org/wiki/Internationalized_domain_name) domain
+/// and checks whether the result is a valid domain.
+#[must_use]
+#[cfg(feature = "unicode_email")]
+fn validate_idn_domain_part(domain_part: &str) -> bool {
+    match idna::domain_to_ascii(domain_part) {
+        Ok(d) => validate_domain_part(&d),
+        Err(_) => false,
+    }
+}
+
+/// IDN domains are only supported with the `unicode_email` feature enabled.
+#[must_use]
+#[cfg(not(feature = "unicode_email"))]
+fn validate_idn_domain_part(_domain_part: &str) -> bool {
+    false
+}
+
 /// Validates whether the given string is an email based on the [HTML5 spec](https://html.spec.whatwg.org/multipage/forms.html#valid-e-mail-address).
 /// [RFC 5322](https://tools.ietf.org/html/rfc5322) is not practical in most circumstances and allows email addresses
 /// that are unfamiliar to most users.
@@ -67,11 +84,8 @@ pub trait ValidateEmail {
         }
 
         if !validate_domain_part(domain_part) {
-            // Still the possibility of an [IDN](https://en.wikipedia.org/wiki/Internationalized_domain_name)
-            return match domain_to_ascii(domain_part) {
-                Ok(d) => validate_domain_part(&d),
-                Err(_) => false,
-            };
+            // Still the possibility of an IDN
+            return validate_idn_domain_part(domain_part);
         }
 
         true
@@ -140,7 +154,6 @@ mod tests {
             ("email@[::fffF:127.0.0.1]", true),
             ("example@valid-----hyphens.com", true),
             ("example@valid-with-hyphens.com", true),
-            ("test@domain.with.idn.tld.उदाहरण.परीक्षा", true),
             (r#""test@test"@example.com"#, false),
             // max length for domain name labels is 63 characters per RFC 1034
             ("a@atm.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", true),
@@ -189,6 +202,15 @@ mod tests {
                 "Email `{input}` was not classified correctly"
             );
         }
+    }
+
+    #[test]
+    fn test_validate_email_idn() {
+        // IDN domains are only recognised when `idna` is available
+        assert_eq!(
+            "test@domain.with.idn.tld.उदाहरण.परीक्षा".validate_email(),
+            cfg!(feature = "unicode_email")
+        );
     }
 
     #[test]

--- a/validator/src/validation/mod.rs
+++ b/validator/src/validation/mod.rs
@@ -11,4 +11,5 @@ pub mod non_control_character;
 pub mod range;
 pub mod regex;
 pub mod required;
+#[cfg(feature = "url")]
 pub mod urls;

--- a/validator/src/validation/mod.rs
+++ b/validator/src/validation/mod.rs
@@ -2,6 +2,7 @@
 pub mod cards;
 pub mod contains;
 pub mod does_not_contain;
+#[cfg(feature = "email")]
 pub mod email;
 pub mod ip;
 pub mod length;
@@ -9,6 +10,7 @@ pub mod must_match;
 // pub mod nested;
 pub mod non_control_character;
 pub mod range;
+#[cfg(feature = "regex")]
 pub mod regex;
 pub mod required;
 #[cfg(feature = "url")]


### PR DESCRIPTION
The idna dependency is currently bringing a massive amount of dependencies.

With this PR, I propose to make it optional (but enabled by default). This ensures there's no breaking changes, but allows a user to manually disable the features, going from 43 unique dependencies to 15 unique dependencies.

```
# before
~$> cargo tree -p validator --no-default-features
validator v0.21.0 (/tmp/tmp.DLFPYjnD2O/validator/validator)
├── idna v1.1.0
│   ├── idna_adapter v1.2.2
│   │   ├── icu_normalizer v2.3.0
│   │   │   ├── icu_collections v2.3.0
│   │   │   │   ├── displaydoc v0.2.7 (proc-macro)
│   │   │   │   │   ├── proc-macro2 v1.0.107
│   │   │   │   │   │   └── unicode-ident v1.0.24
│   │   │   │   │   ├── quote v1.0.47
│   │   │   │   │   │   └── proc-macro2 v1.0.107 (*)
│   │   │   │   │   └── syn v3.0.5
│   │   │   │   │       ├── proc-macro2 v1.0.107 (*)
│   │   │   │   │       ├── quote v1.0.47 (*)
│   │   │   │   │       └── unicode-ident v1.0.24
│   │   │   │   ├── potential_utf v0.1.6
│   │   │   │   │   └── zerovec v0.11.8
│   │   │   │   │       ├── yoke v0.8.3
│   │   │   │   │       │   ├── stable_deref_trait v1.2.1
│   │   │   │   │       │   ├── yoke-derive v0.8.2 (proc-macro)
│   │   │   │   │       │   │   ├── proc-macro2 v1.0.107 (*)
│   │   │   │   │       │   │   ├── quote v1.0.47 (*)
│   │   │   │   │       │   │   ├── syn v2.0.119
│   │   │   │   │       │   │   │   ├── proc-macro2 v1.0.107 (*)
│   │   │   │   │       │   │   │   ├── quote v1.0.47 (*)
│   │   │   │   │       │   │   │   └── unicode-ident v1.0.24
│   │   │   │   │       │   │   └── synstructure v0.13.2
│   │   │   │   │       │   │       ├── proc-macro2 v1.0.107 (*)
│   │   │   │   │       │   │       ├── quote v1.0.47 (*)
│   │   │   │   │       │   │       └── syn v2.0.119 (*)
│   │   │   │   │       │   └── zerofrom v0.1.8
│   │   │   │   │       │       └── zerofrom-derive v0.1.7 (proc-macro)
│   │   │   │   │       │           ├── proc-macro2 v1.0.107 (*)
│   │   │   │   │       │           ├── quote v1.0.47 (*)
│   │   │   │   │       │           ├── syn v2.0.119 (*)
│   │   │   │   │       │           └── synstructure v0.13.2 (*)
│   │   │   │   │       ├── zerofrom v0.1.8 (*)
│   │   │   │   │       └── zerovec-derive v0.11.6 (proc-macro)
│   │   │   │   │           ├── proc-macro2 v1.0.107 (*)
│   │   │   │   │           ├── quote v1.0.47 (*)
│   │   │   │   │           └── syn v3.0.5 (*)
│   │   │   │   ├── utf8_iter v1.0.4
│   │   │   │   ├── yoke v0.8.3 (*)
│   │   │   │   ├── zerofrom v0.1.8 (*)
│   │   │   │   └── zerovec v0.11.8 (*)
│   │   │   ├── icu_normalizer_data v2.3.0
│   │   │   ├── icu_provider v2.3.1
│   │   │   │   ├── displaydoc v0.2.7 (proc-macro) (*)
│   │   │   │   ├── icu_locale_core v2.3.0
│   │   │   │   │   ├── displaydoc v0.2.7 (proc-macro) (*)
│   │   │   │   │   ├── litemap v0.8.3
│   │   │   │   │   ├── tinystr v0.8.4
│   │   │   │   │   │   ├── displaydoc v0.2.7 (proc-macro) (*)
│   │   │   │   │   │   └── zerovec v0.11.8 (*)
│   │   │   │   │   ├── writeable v0.6.4
│   │   │   │   │   └── zerovec v0.11.8 (*)
│   │   │   │   ├── writeable v0.6.4
│   │   │   │   ├── yoke v0.8.3 (*)
│   │   │   │   ├── zerofrom v0.1.8 (*)
│   │   │   │   ├── zerotrie v0.2.5
│   │   │   │   │   ├── displaydoc v0.2.7 (proc-macro) (*)
│   │   │   │   │   ├── yoke v0.8.3 (*)
│   │   │   │   │   └── zerofrom v0.1.8 (*)
│   │   │   │   └── zerovec v0.11.8 (*)
│   │   │   ├── smallvec v1.16.0
│   │   │   └── zerovec v0.11.8 (*)
│   │   └── icu_properties v2.3.0
│   │       ├── displaydoc v0.2.7 (proc-macro) (*)
│   │       ├── icu_collections v2.3.0 (*)
│   │       ├── icu_locale_core v2.3.0 (*)
│   │       ├── icu_properties_data v2.3.0
│   │       ├── icu_provider v2.3.1 (*)
│   │       ├── zerotrie v0.2.5 (*)
│   │       └── zerovec v0.11.8 (*)
│   ├── smallvec v1.16.0
│   └── utf8_iter v1.0.4
├── regex v1.13.1
│   ├── regex-automata v0.4.18
│   │   └── regex-syntax v0.8.11
│   └── regex-syntax v0.8.11
├── serde v1.0.229
│   └── serde_core v1.0.229
├── serde_derive v1.0.229 (proc-macro)
│   ├── proc-macro2 v1.0.107 (*)
│   ├── quote v1.0.47 (*)
│   └── syn v3.0.5 (*)
├── serde_json v1.0.151
│   ├── itoa v1.0.18
│   ├── memchr v2.8.3
│   ├── serde_core v1.0.229
│   └── zmij v1.0.23
└── url v2.5.8
    ├── form_urlencoded v1.2.2
    │   └── percent-encoding v2.3.2
    ├── idna v1.1.0 (*)
    └── percent-encoding v2.3.2

# after
~$> cargo tree -p validator --no-default-features
validator v0.21.0 (/tmp/tmp.DLFPYjnD2O/validator/validator)
├── regex v1.13.1
│   ├── regex-automata v0.4.18
│   │   └── regex-syntax v0.8.11
│   └── regex-syntax v0.8.11
├── serde v1.0.229
│   └── serde_core v1.0.229
├── serde_derive v1.0.229 (proc-macro)
│   ├── proc-macro2 v1.0.107
│   │   └── unicode-ident v1.0.24
│   ├── quote v1.0.47
│   │   └── proc-macro2 v1.0.107 (*)
│   └── syn v3.0.5
│       ├── proc-macro2 v1.0.107 (*)
│       ├── quote v1.0.47 (*)
│       └── unicode-ident v1.0.24
└── serde_json v1.0.151
    ├── itoa v1.0.18
    ├── memchr v2.8.3
    ├── serde_core v1.0.229
    └── zmij v1.0.23
```

